### PR TITLE
fix: 修复登录页设置按钮被 SafeArea 覆盖无法点击

### DIFF
--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -227,15 +227,6 @@ class _LoginPageState extends State<LoginPage> {
                 ),
               ),
             ),
-            Positioned(
-              top: MediaQuery.paddingOf(context).top + 10,
-              right: 16,
-              child: IconButton(
-                tooltip: '设置 API 服务器地址',
-                icon: const Icon(Icons.dns_rounded),
-                onPressed: () => _editApiBaseUrl(context),
-              ),
-            ),
             SafeArea(
               child: LayoutBuilder(
                 builder: (context, constraints) {
@@ -278,6 +269,15 @@ class _LoginPageState extends State<LoginPage> {
                     ),
                   );
                 },
+              ),
+            ),
+            Positioned(
+              top: MediaQuery.paddingOf(context).top + 10,
+              right: 16,
+              child: IconButton(
+                tooltip: '设置 API 服务器地址',
+                icon: const Icon(Icons.dns_rounded),
+                onPressed: () => _editApiBaseUrl(context),
               ),
             ),
           ],


### PR DESCRIPTION
## Bug 描述
登录页右上角"设置 API 服务器地址"的 IconButton 无法点击。

## 原因
该 IconButton 位于 SafeArea 之前，被其后绘制的 SafeArea 覆盖，
导致无法响应点击事件。

## 修复方案
将 IconButton 调整到 SafeArea 之后，确保它处于最上层可正常响应点击。