### PR TITLE
feat: 新增查看歌手功能及歌手页底部播放卡片

### DIFF
--- a/lib/models/music_models.dart
+++ b/lib/models/music_models.dart
@@ -1007,7 +1007,7 @@ List<ArtistRef> parseArtists(
     );
   }
 
-  for (final key in const ['singerinfo', 'authors', 'author', 'singers']) {
+  for (final key in const ['singerinfo', 'authors', 'author', 'singers', 'Singers']) {
     final value = json[key];
     if (value is List) {
       for (final item in value.whereType<Map<String, dynamic>>()) {

--- a/lib/ui/pages/artist_detail_page.dart
+++ b/lib/ui/pages/artist_detail_page.dart
@@ -5,6 +5,7 @@ import '../../controllers/player_controller.dart';
 import '../../models/music_models.dart';
 import '../../services/music_api.dart';
 import '../widgets/artwork.dart';
+import '../widgets/mini_player.dart';
 import '../widgets/now_playing_badge.dart';
 import '../widgets/song_action_sheets.dart';
 import '../adaptive_layout.dart';
@@ -179,6 +180,9 @@ class _ArtistDetailPageState extends State<ArtistDetailPage> {
 
   @override
   Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+    // MiniPlayer 高度约 64，距底部 16，合计预留空间防止遮挡最后一首歌
+    final miniPlayerSpace = bottomInset + 64 + 16;
     return Scaffold(
       extendBodyBehindAppBar: true,
       appBar: AppBar(
@@ -189,73 +193,100 @@ class _ArtistDetailPageState extends State<ArtistDetailPage> {
         title: const SizedBox.shrink(),
       ),
       body: AdaptiveContentPadding(
-        child: CustomScrollView(
-        controller: _scrollController,
-        slivers: [
-          SliverToBoxAdapter(
-            child: _ArtistHeader(detail: _detail, fallback: widget.artist),
-          ),
-          if (_isInitialLoading)
-            const _ArtistDetailSkeleton()
-          else if (_errorMessage case final message?)
-            SliverFillRemaining(
-              hasScrollBody: false,
-              child: _ArtistDetailError(
-                message: message,
-                onRetry: _loadInitial,
-              ),
-            )
-          else ...[
-            SliverToBoxAdapter(
-              child: _SongSectionHeader(
-                count: _songs.length,
-                onPlayAll: _songs.isEmpty
-                    ? null
-                    : () => widget.player.playSong(
-                        _songs.first,
-                        queue: List<Song>.of(_songs),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Positioned.fill(
+              child: CustomScrollView(
+                controller: _scrollController,
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: _ArtistHeader(detail: _detail, fallback: widget.artist),
+                  ),
+                  if (_isInitialLoading)
+                    const _ArtistDetailSkeleton()
+                  else if (_errorMessage case final message?)
+                    SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: _ArtistDetailError(
+                        message: message,
+                        onRetry: _loadInitial,
                       ),
+                    )
+                  else ...[
+                    SliverToBoxAdapter(
+                      child: _SongSectionHeader(
+                        count: _songs.length,
+                        onPlayAll: _songs.isEmpty
+                            ? null
+                            : () => widget.player.playSong(
+                                _songs.first,
+                                queue: List<Song>.of(_songs),
+                              ),
+                      ),
+                    ),
+                    if (_songs.isEmpty)
+                      const SliverFillRemaining(
+                        hasScrollBody: false,
+                        child: _EmptyArtistSongs(),
+                      )
+                    else ...[
+                      SliverPadding(
+                        padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                        sliver: SliverList.separated(
+                          itemCount: _songs.length,
+                          separatorBuilder: (_, _) => const SizedBox(height: 2),
+                          itemBuilder: (context, index) {
+                            final song = _songs[index];
+                            return _ArtistSongRow(
+                              song: song,
+                              auth: widget.auth,
+                              player: widget.player,
+                              onTap: () => widget.player.playSong(
+                                song,
+                                queue: List<Song>.of(_songs),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      SliverToBoxAdapter(
+                        child: _ArtistLoadMoreFooter(
+                          hasMore: _hasMore,
+                          isLoading: _isLoadingMore,
+                          errorMessage: _loadMoreError,
+                          onRetry: _loadMore,
+                        ),
+                      ),
+                      // 底部留白：播放中时为 MiniPlayer 预留空间，
+                      // 防止卡片遮挡导致用户点不到最底部的几首歌。
+                      SliverToBoxAdapter(
+                        child: AnimatedBuilder(
+                          animation: widget.player,
+                          builder: (context, _) {
+                            final hasSong = widget.player.currentSong != null;
+                            return SizedBox(height: hasSong ? miniPlayerSpace : 0);
+                          },
+                        ),
+                      ),
+                    ],
+                  ],
+                ],
               ),
             ),
-            if (_songs.isEmpty)
-              const SliverFillRemaining(
-                hasScrollBody: false,
-                child: _EmptyArtistSongs(),
-              )
-            else ...[
-              SliverPadding(
-                padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-                sliver: SliverList.separated(
-                  itemCount: _songs.length,
-                  separatorBuilder: (_, _) => const SizedBox(height: 2),
-                  itemBuilder: (context, index) {
-                    final song = _songs[index];
-                    return _ArtistSongRow(
-                      song: song,
-                      auth: widget.auth,
-                      player: widget.player,
-                      onTap: () => widget.player.playSong(
-                        song,
-                        queue: List<Song>.of(_songs),
-                      ),
-                    );
-                  },
-                ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: bottomInset + 16,
+              child: MiniPlayer(
+                player: widget.player,
+                auth: widget.auth,
               ),
-              SliverToBoxAdapter(
-                child: _ArtistLoadMoreFooter(
-                  hasMore: _hasMore,
-                  isLoading: _isLoadingMore,
-                  errorMessage: _loadMoreError,
-                  onRetry: _loadMore,
-                ),
-              ),
-            ],
+            ),
           ],
-        ],
+        ),
       ),
-    ),
-  );
+    );
   }
 }
 

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -14,6 +14,7 @@ import '../widgets/now_playing_badge.dart';
 import '../widgets/song_action_sheets.dart';
 import '../widgets/toast.dart';
 import 'album_shop_page.dart';
+import 'artist_detail_page.dart';
 import 'playlist_detail_page.dart';
 import 'search_page.dart';
 
@@ -239,6 +240,24 @@ class _HomePageState extends State<HomePage> {
     widget.player.playSong(song, queue: queue);
   }
 
+  void _openArtist(Song song) {
+    final artist = song.artists.firstWhere(
+      (a) => a.name.isNotEmpty,
+      orElse: () => const ArtistRef(id: '', name: ''),
+    );
+    if (artist.name.isEmpty) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ArtistDetailPage(
+          api: widget.api,
+          auth: widget.auth,
+          artist: artist,
+          player: widget.player,
+        ),
+      ),
+    );
+  }
+
   void _openAlbumShop() {
     Navigator.of(context).push(
       MaterialPageRoute(
@@ -320,6 +339,7 @@ class _HomePageState extends State<HomePage> {
                               onLikeTap: (song) => widget.auth.toggleLike(song),
                               auth: widget.auth,
                               player: widget.player,
+                              onViewArtist: _openArtist,
                             ),
                             _PlaylistRail(
                               playlists: data.playlists,
@@ -759,6 +779,7 @@ class _SongSection extends StatefulWidget {
     required this.onLikeTap,
     required this.auth,
     required this.player,
+    required this.onViewArtist,
   });
 
   final String title;
@@ -768,6 +789,7 @@ class _SongSection extends StatefulWidget {
   final void Function(Song song) onLikeTap;
   final AuthController auth;
   final PlayerController player;
+  final void Function(Song song) onViewArtist;
 
   @override
   State<_SongSection> createState() => _SongSectionState();
@@ -850,6 +872,7 @@ class _SongSectionState extends State<_SongSection> {
                                     onLikeTap: () => widget.onLikeTap(pageSongs[i]),
                                     auth: widget.auth,
                                     player: widget.player,
+                                    onViewArtist: () => widget.onViewArtist(pageSongs[i]),
                                   ),
                               ],
                             ),
@@ -868,6 +891,7 @@ class _SongSectionState extends State<_SongSection> {
                                       onLikeTap: () => widget.onLikeTap(pageSongs[i]),
                                       auth: widget.auth,
                                       player: widget.player,
+                                      onViewArtist: () => widget.onViewArtist(pageSongs[i]),
                                     ),
                                 ],
                               ),
@@ -888,6 +912,7 @@ class _SongSectionState extends State<_SongSection> {
                             onLikeTap: () => widget.onLikeTap(song),
                             auth: widget.auth,
                             player: widget.player,
+                            onViewArtist: () => widget.onViewArtist(song),
                           ),
                       ],
                     );
@@ -935,6 +960,7 @@ class _HomeSongRow extends StatelessWidget {
     required this.onLikeTap,
     required this.auth,
     required this.player,
+    required this.onViewArtist,
   });
 
   final Song song;
@@ -944,6 +970,7 @@ class _HomeSongRow extends StatelessWidget {
   final VoidCallback onLikeTap;
   final AuthController auth;
   final PlayerController player;
+  final VoidCallback onViewArtist;
 
   @override
   Widget build(BuildContext context) {
@@ -1060,6 +1087,11 @@ class _HomeSongRow extends StatelessWidget {
                             auth: auth,
                             song: song,
                           ),
+                        ),
+                        SongSheetAction(
+                          icon: Icons.person_rounded,
+                          title: '查看歌手',
+                          onTap: onViewArtist,
                         ),
                         if (player.downloadController != null)
                           SongSheetAction(

--- a/lib/ui/pages/search_page.dart
+++ b/lib/ui/pages/search_page.dart
@@ -13,6 +13,7 @@ import '../widgets/now_playing_badge.dart';
 import '../widgets/song_action_sheets.dart';
 import '../widgets/toast.dart';
 import '../adaptive_layout.dart';
+import 'artist_detail_page.dart';
 
 class SearchPage extends StatefulWidget {
   const SearchPage({
@@ -166,6 +167,28 @@ class _SearchPageState extends State<SearchPage> {
     widget.player.playSong(song, queue: _results);
   }
 
+  void _openArtist(Song song) {
+    if (song.source != SongSource.kugou) {
+      Toast.info('其他平台歌曲暂不支持查看歌手');
+      return;
+    }
+    final artist = song.artists.firstWhere(
+      (a) => a.name.isNotEmpty,
+      orElse: () => const ArtistRef(id: '', name: ''),
+    );
+    if (artist.name.isEmpty) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ArtistDetailPage(
+          api: widget.api,
+          auth: widget.auth,
+          artist: artist,
+          player: widget.player,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -275,6 +298,7 @@ class _SearchPageState extends State<SearchPage> {
               onLikeTap: (song) => widget.auth.toggleLike(song),
               auth: widget.auth,
               player: widget.player,
+              onViewArtist: _openArtist,
             );
     }
 
@@ -781,6 +805,7 @@ class _SearchResults extends StatelessWidget {
     required this.onLikeTap,
     required this.auth,
     required this.player,
+    required this.onViewArtist,
   });
 
   final List<Song> songs;
@@ -789,6 +814,7 @@ class _SearchResults extends StatelessWidget {
   final void Function(Song song) onLikeTap;
   final AuthController auth;
   final PlayerController player;
+  final void Function(Song song) onViewArtist;
 
   @override
   Widget build(BuildContext context) {
@@ -929,6 +955,11 @@ class _SearchResults extends StatelessWidget {
                                       auth: auth,
                                       song: song,
                                     ),
+                                  ),
+                                  SongSheetAction(
+                                    icon: Icons.person_rounded,
+                                    title: '查看歌手',
+                                    onTap: () => onViewArtist(song),
                                   ),
                                   if (player.downloadController != null)
                                     SongSheetAction(


### PR DESCRIPTION
## 功能说明
本 PR 新增"查看歌手"功能并优化歌手详情页体验，包含三个提交：

1. fix: 修复 parseArtists 未匹配 Singers 大写导致歌手ID解析失败
   - 部分接口返回的歌手字段名为大写 Singers，原解析只匹配小写 singers，
     导致查看歌手时无法正确解析歌手 ID。在候选 key 列表中补充 'Singers'。

2. feat: 首页和搜索页歌曲菜单添加查看歌手功能
   - 在首页推荐歌曲和搜索结果的歌曲长按菜单中新增"查看歌手"入口，
     点击后跳转到对应歌手的详情页。

3. feat: 歌手页添加底部播放卡片并留白防遮挡
   - 歌手详情页底部新增迷你播放卡片，并在歌曲列表底部留白避免被遮挡；
     无播放时自动隐藏。

## 测试
- 首页/搜索页歌曲菜单"查看歌手"可正常跳转
- 歌手详情页底部播放卡片正常显示，不遮挡最后一首歌
- 无播放时播放卡片自动隐藏