### PR TITLE
feat: 新增扫码登录功能

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -292,8 +292,47 @@ class AuthController extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_tokenKey, session.token ?? '');
       await prefs.setString(_t1Key, session.t1 ?? '');
-      await prefs.setString(_sessionIdKey, session.sessionId ?? '');
+      // session.sessionId 可能为 null（扫码登录），但 ApiClient 内部
+      // 已从登录响应 header 保存了后端的 session key，这里也持久化一份。
+      await prefs.setString(_sessionIdKey, _api.clientSessionId ?? '');
       await prefs.setString(_userIdKey, session.userId ?? '');
+
+      // 扫码登录返回的 QrLoginStatusResponse 只有 token，缺少 t1。
+      // 后续 /user/detail 等接口需要 t1 header 鉴权，否则会失败导致
+      // profile/歌单拉取不到。这里先调 /login/token 刷新拿到 t1。
+      if (session.t1 == null || session.t1!.isEmpty) {
+        try {
+          final refreshed = await _api.refreshToken();
+          if (refreshed.token != null && refreshed.token!.isNotEmpty) {
+            // 合并：保留扫码返回的 nickname/avatar，用刷新结果的 token/t1
+            session = LoginSession(
+              userId: refreshed.userId ?? session.userId,
+              token: refreshed.token,
+              t1: refreshed.t1,
+              sessionId: _api.clientSessionId,
+              nickname: session.nickname,
+              avatarUrl: session.avatarUrl,
+            );
+            this.session = session;
+            _api.setSession(session);
+            await prefs.setString(_tokenKey, session.token ?? '');
+            await prefs.setString(_t1Key, session.t1 ?? '');
+            await prefs.setString(_sessionIdKey, _api.clientSessionId ?? '');
+            await prefs.setString(_userIdKey, session.userId ?? '');
+          }
+        } catch (_) {
+          // 刷新失败，继续用原 token
+        }
+      }
+
+      // 用 session 数据构造临时 profile，UI 立即展示用户信息；
+      // refreshProfile 成功后会覆盖为完整数据。
+      if (session.nickname != null && session.nickname!.isNotEmpty) {
+        profile = UserProfile(
+          nickname: session.nickname!,
+          avatarUrl: session.avatarUrl,
+        );
+      }
 
       await refreshProfile(silent: true);
       _vipBackgroundTask.schedule(session);
@@ -323,7 +362,8 @@ class AuthController extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_tokenKey, nextSession.token ?? '');
       await prefs.setString(_t1Key, nextSession.t1 ?? '');
-      await prefs.setString(_sessionIdKey, nextSession.sessionId ?? '');
+      // nextSession.sessionId 可能为 null，用 ApiClient 实际持有的 session key
+      await prefs.setString(_sessionIdKey, _api.clientSessionId ?? '');
       await prefs.setString(_userIdKey, nextSession.userId ?? '');
 
       await refreshProfile(silent: true);

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -284,6 +284,22 @@ class AuthController extends ChangeNotifier {
     await _run(() => _api.sendLoginCode(mobile));
   }
 
+  Future<void> loginWithSession(LoginSession session) async {
+    await _run(() async {
+      this.session = session;
+      _api.setSession(session);
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_tokenKey, session.token ?? '');
+      await prefs.setString(_t1Key, session.t1 ?? '');
+      await prefs.setString(_sessionIdKey, session.sessionId ?? '');
+      await prefs.setString(_userIdKey, session.userId ?? '');
+
+      await refreshProfile(silent: true);
+      _vipBackgroundTask.schedule(session);
+    });
+  }
+
   Future<PhoneLoginResult?> login(
     String mobile,
     String code, {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -151,7 +151,7 @@ class _KaMusicAppState extends State<KaMusicApp> with WidgetsBindingObserver {
             animation: _auth,
             builder: (context, _) {
               if (!_auth.isRestoring && !_auth.isLoggedIn) {
-                return LoginPage(auth: _auth);
+                return LoginPage(auth: _auth, api: _api);
               }
 
               return AppShell(

--- a/lib/models/music_models.dart
+++ b/lib/models/music_models.dart
@@ -1,10 +1,19 @@
 class LoginSession {
-  const LoginSession({this.userId, this.token, this.t1, this.sessionId});
+  const LoginSession({
+    this.userId,
+    this.token,
+    this.t1,
+    this.sessionId,
+    this.nickname,
+    this.avatarUrl,
+  });
 
   final String? userId;
   final String? token;
   final String? t1;
   final String? sessionId;
+  final String? nickname;
+  final String? avatarUrl;
 
   bool get isValid =>
       (token != null && token!.isNotEmpty) ||
@@ -1600,6 +1609,51 @@ class SearchHotCategory {
           .whereType<Map<String, dynamic>>()
           .map(SearchHotKeyword.fromJson)
           .toList(),
+    );
+  }
+}
+
+class QrCodeInfo {
+  const QrCodeInfo({required this.key, required this.imageUrl});
+
+  final String key;
+  final String imageUrl;
+
+  factory QrCodeInfo.fromJson(Map<String, dynamic> json) {
+    return QrCodeInfo(
+      key: asString(json['qrcode']) ?? '',
+      imageUrl: asString(json['qrcode_img']) ?? '',
+    );
+  }
+}
+
+class QrCheckResult {
+  const QrCheckResult({
+    required this.status,
+    this.token,
+    this.userId,
+    this.nickname,
+    this.avatar,
+  });
+
+  final int status;
+  final String? token;
+  final String? userId;
+  final String? nickname;
+  final String? avatar;
+
+  bool get isExpired => status == 0;
+  bool get isWaitingForScan => status == 1;
+  bool get isWaitingForConfirm => status == 2;
+  bool get isSuccess => status == 4 && token != null && token!.isNotEmpty;
+
+  factory QrCheckResult.fromJson(Map<String, dynamic> json) {
+    return QrCheckResult(
+      status: asInt(json['status']) ?? 0,
+      token: asString(json['token']),
+      userId: asString(json['userid']),
+      nickname: asString(json['nickname']),
+      avatar: asString(json['pic']),
     );
   }
 }

--- a/lib/models/music_models.dart
+++ b/lib/models/music_models.dart
@@ -1642,9 +1642,10 @@ class QrCheckResult {
   final String? nickname;
   final String? avatar;
 
-  bool get isExpired => status == 0;
-  bool get isWaitingForScan => status == 1;
-  bool get isWaitingForConfirm => status == 2;
+  // 酷狗二维码状态码：0=等待扫码, 1=已扫码待确认, 2=已过期, 4=登录成功
+  bool get isWaitingForScan => status == 0;
+  bool get isWaitingForConfirm => status == 1;
+  bool get isExpired => status == 2;
   bool get isSuccess => status == 4 && token != null && token!.isNotEmpty;
 
   factory QrCheckResult.fromJson(Map<String, dynamic> json) {

--- a/lib/services/music_api.dart
+++ b/lib/services/music_api.dart
@@ -14,10 +14,27 @@ class MusicApi {
 
   final ApiClient _client;
 
+  /// 暴露 ApiClient 当前持有的后端 session key（由响应 header 自动保存）。
+  String? get clientSessionId => _client.sessionId;
+
   void setSession(LoginSession? session) {
-    _client.token = session?.token;
-    _client.t1 = session?.t1;
-    _client.sessionId = session?.sessionId;
+    if (session == null) {
+      _client.token = null;
+      _client.t1 = null;
+      _client.sessionId = null;
+      return;
+    }
+    _client.token = session.token;
+    _client.t1 = session.t1;
+    // 扫码/手机号登录返回的 session 不携带 sessionId，
+    // 此时 _client.sessionId 已由 ApiClient._processResponse 从
+    // 登录请求的响应 header (X-Kg-Session-Id) 中保存。
+    // 不能用 null 覆盖，否则后续请求无法关联到后端 session，
+    // 导致 /user/detail、/user/playlist 等接口拿不到登录态。
+    final sid = session.sessionId;
+    if (sid != null && sid.isNotEmpty) {
+      _client.sessionId = sid;
+    }
   }
 
   Future<void> sendLoginCode(String mobile) async {

--- a/lib/services/music_api.dart
+++ b/lib/services/music_api.dart
@@ -86,6 +86,16 @@ class MusicApi {
     await _client.post('/login/logout');
   }
 
+  Future<QrCodeInfo> getQrCode() async {
+    final json = asMap(await _client.get('/login/qr/key'));
+    return QrCodeInfo.fromJson(json);
+  }
+
+  Future<QrCheckResult> checkQrStatus(String key) async {
+    final json = asMap(await _client.get('/login/qr/check', {'key': key}));
+    return QrCheckResult.fromJson(json);
+  }
+
   Future<UserProfile> userDetail() async {
     final json = asMap(await _client.get('/user/detail'));
     return UserProfile.fromJson(json);

--- a/lib/ui/adaptive_layout.dart
+++ b/lib/ui/adaptive_layout.dart
@@ -21,6 +21,22 @@ class AdaptiveLayout {
     final size = MediaQuery.sizeOf(context);
     return size.shortestSide >= 600;
   }
+
+  /// 不依赖 [BuildContext] 的平板判断。
+  ///
+  /// 直接从 [PlatformDispatcher] 读取屏幕物理尺寸换算为逻辑像素。
+  /// 适用于 [State.dispose] 等 context 已失效、无法调用
+  /// [MediaQuery.sizeOf] 的场景，否则会触发
+  /// `Null check operator used on a null value` 异常。
+  static bool isTabletByPlatform() {
+    final views = WidgetsBinding.instance.platformDispatcher.views;
+    if (views.isEmpty) return false;
+    final view = views.first;
+    final physical = view.physicalSize;
+    if (physical.isEmpty) return false;
+    final size = physical / view.devicePixelRatio;
+    return size.shortestSide >= 600;
+  }
 }
 
 /// 自适应内容内边距。

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -227,15 +227,6 @@ class _LoginPageState extends State<LoginPage> {
                 ),
               ),
             ),
-            Positioned(
-              top: MediaQuery.paddingOf(context).top + 10,
-              right: 16,
-              child: IconButton(
-                tooltip: '设置 API 服务器地址',
-                icon: const Icon(Icons.dns_rounded),
-                onPressed: () => _editApiBaseUrl(context),
-              ),
-            ),
             SafeArea(
               child: LayoutBuilder(
                 builder: (context, constraints) {
@@ -278,6 +269,15 @@ class _LoginPageState extends State<LoginPage> {
                     ),
                   );
                 },
+              ),
+            ),
+            Positioned(
+              top: MediaQuery.paddingOf(context).top + 10,
+              right: 16,
+              child: IconButton(
+                tooltip: '设置 API 服务器地址',
+                icon: const Icon(Icons.dns_rounded),
+                onPressed: () => _editApiBaseUrl(context),
               ),
             ),
           ],

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -1009,26 +1009,11 @@ class _QrLoginForm extends StatelessWidget {
             else if (qrCode != null && qrCode!.imageUrl.isNotEmpty)
               ClipRRect(
                 borderRadius: BorderRadius.circular(16),
-                child: Image.network(
-                  qrCode!.imageUrl,
-                  width: 200,
-                  height: 200,
-                  fit: BoxFit.contain,
-                  errorBuilder: (_, __, ___) {
-                    return Container(
-                      width: 200,
-                      height: 200,
-                      decoration: BoxDecoration(
-                        color: colorScheme.surfaceContainerHighest,
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      child: Icon(
-                        Icons.qr_code_2_rounded,
-                        size: 80,
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                    );
-                  },
+                child: _QrImage(
+                  imageUrl: qrCode!.imageUrl,
+                  size: 200,
+                  fallbackColor: colorScheme.surfaceContainerHighest,
+                  iconColor: colorScheme.onSurfaceVariant,
                 ),
               )
             else
@@ -1082,6 +1067,68 @@ class _QrLoginForm extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// 渲染二维码图片。
+///
+/// 后端 `/login/qr/key` 返回的 `qrcode_img` 是 `data:image/png;base64,...`
+/// 形式的 data URI，[Image.network] 无法直接加载，会触发 "Width is zero"
+/// 渲染警告并导致二维码不显示。这里自动识别 data URI 并走 [Image.memory]，
+/// 普通 http(s) URL 仍走 [Image.network]。
+class _QrImage extends StatelessWidget {
+  const _QrImage({
+    required this.imageUrl,
+    required this.size,
+    required this.fallbackColor,
+    required this.iconColor,
+  });
+
+  final String imageUrl;
+  final double size;
+  final Color fallbackColor;
+  final Color iconColor;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget fallback() => Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: fallbackColor,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Icon(
+            Icons.qr_code_2_rounded,
+            size: 80,
+            color: iconColor,
+          ),
+        );
+
+    final uri = Uri.tryParse(imageUrl);
+    if (uri == null) return fallback();
+
+    // data:image/png;base64,... -> 解码字节后用 Image.memory 渲染
+    final data = uri.data;
+    if (data != null) {
+      final bytes = data.contentAsBytes();
+      if (bytes.isEmpty) return fallback();
+      return Image.memory(
+        bytes,
+        width: size,
+        height: size,
+        fit: BoxFit.contain,
+        errorBuilder: (_, __, ___) => fallback(),
+      );
+    }
+
+    return Image.network(
+      imageUrl,
+      width: size,
+      height: size,
+      fit: BoxFit.contain,
+      errorBuilder: (_, __, ___) => fallback(),
     );
   }
 }

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -7,12 +7,14 @@ import 'package:flutter/services.dart';
 import '../../config/app_config.dart';
 import '../../controllers/auth_controller.dart';
 import '../../models/music_models.dart';
+import '../../services/music_api.dart';
 import '../widgets/toast.dart';
 
 class LoginPage extends StatefulWidget {
-  const LoginPage({super.key, required this.auth});
+  const LoginPage({super.key, required this.auth, required this.api});
 
   final AuthController auth;
+  final MusicApi api;
 
   @override
   State<LoginPage> createState() => _LoginPageState();
@@ -29,9 +31,17 @@ class _LoginPageState extends State<LoginPage> {
   String? _localError;
   int _codeSeconds = 0;
 
+  var _tabIndex = 0;
+  QrCodeInfo? _qrCode;
+  String _qrStatusText = '';
+  bool _qrLoading = false;
+  bool _qrExpired = false;
+  Timer? _qrPollTimer;
+
   @override
   void dispose() {
     _codeTimer?.cancel();
+    _qrPollTimer?.cancel();
     _mobileController.dispose();
     _codeController.dispose();
     _mobileFocus.dispose();
@@ -96,9 +106,8 @@ class _LoginPageState extends State<LoginPage> {
     final result = await widget.auth.login(mobile, code);
     if (!mounted || result?.requiresUserSelection != true) {
       return;
-    }
-    await _showAccountSelection(result!.accounts, mobile, code, result.message);
   }
+}
 
   Future<void> _showAccountSelection(
     List<MobileLoginAccount> accounts,
@@ -196,6 +205,69 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  Future<void> _loadQrCode() async {
+    _qrPollTimer?.cancel();
+    setState(() {
+      _qrCode = null;
+      _qrStatusText = '获取二维码中...';
+      _qrLoading = true;
+      _qrExpired = false;
+    });
+    try {
+      final qr = await widget.api.getQrCode();
+      if (!mounted) return;
+      setState(() {
+        _qrCode = qr;
+        _qrLoading = false;
+        _qrStatusText = '请使用酷狗音乐App扫码';
+      });
+      _startQrPolling(qr.key);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _qrLoading = false;
+        _qrStatusText = '获取二维码失败，点击重试';
+        _qrExpired = true;
+      });
+    }
+  }
+
+  void _startQrPolling(String key) {
+    _qrPollTimer?.cancel();
+    _qrPollTimer = Timer.periodic(const Duration(seconds: 2), (_) async {
+      try {
+        final result = await widget.api.checkQrStatus(key);
+        if (!mounted) return;
+        if (result.isSuccess) {
+          _qrPollTimer?.cancel();
+          final session = LoginSession(
+            userId: result.userId ?? '',
+            token: result.token ?? '',
+            nickname: result.nickname,
+            avatarUrl: result.avatar,
+          );
+          await widget.auth.loginWithSession(session);
+          return;
+        }
+        if (result.isExpired) {
+          _qrPollTimer?.cancel();
+          setState(() {
+            _qrStatusText = '二维码已过期，点击刷新';
+            _qrExpired = true;
+          });
+          return;
+        }
+        setState(() {
+          _qrStatusText = result.isWaitingForConfirm
+              ? '扫码成功，请在手机上确认'
+              : '请使用酷狗音乐App扫码';
+        });
+      } catch (_) {
+        if (!mounted) return;
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -250,18 +322,35 @@ class _LoginPageState extends State<LoginPage> {
                             children: [
                               _LoginHeader(colorScheme: colorScheme),
                               const SizedBox(height: 28),
-                              _LoginForm(
-                                auth: widget.auth,
-                                codeController: _codeController,
-                                codeFocus: _codeFocus,
-                                codeSeconds: _codeSeconds,
-                                errorText:
-                                    _localError ?? widget.auth.errorMessage,
-                                mobileController: _mobileController,
-                                mobileFocus: _mobileFocus,
-                                onLogin: _login,
-                                onSendCode: _sendCode,
+                              _LoginTabBar(
+                                selectedIndex: _tabIndex,
+                                onChanged: (i) {
+                                  setState(() => _tabIndex = i);
+                                  if (i == 1) _loadQrCode();
+                                },
                               ),
+                              const SizedBox(height: 20),
+                              if (_tabIndex == 0)
+                                _LoginForm(
+                                  auth: widget.auth,
+                                  codeController: _codeController,
+                                  codeFocus: _codeFocus,
+                                  codeSeconds: _codeSeconds,
+                                  errorText:
+                                      _localError ?? widget.auth.errorMessage,
+                                  mobileController: _mobileController,
+                                  mobileFocus: _mobileFocus,
+                                  onLogin: _login,
+                                  onSendCode: _sendCode,
+                                )
+                              else
+                                _QrLoginForm(
+                                  qrCode: _qrCode,
+                                  isLoading: _qrLoading,
+                                  statusText: _qrStatusText,
+                                  isExpired: _qrExpired,
+                                  onRefresh: _loadQrCode,
+                                ),
                             ],
                           ),
                         ),
@@ -793,6 +882,205 @@ class _PrimaryLoginButton extends StatelessWidget {
                   fontWeight: FontWeight.w900,
                 ),
               ),
+      ),
+    );
+  }
+}
+
+class _LoginTabBar extends StatelessWidget {
+  const _LoginTabBar({required this.selectedIndex, required this.onChanged});
+
+  final int selectedIndex;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: .68),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: GestureDetector(
+              onTap: () => onChanged(0),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: selectedIndex == 0
+                      ? colorScheme.surface
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  '手机号登录',
+                  style: TextStyle(
+                    color: selectedIndex == 0
+                        ? colorScheme.onSurface
+                        : colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: GestureDetector(
+              onTap: () => onChanged(1),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                decoration: BoxDecoration(
+                  color: selectedIndex == 1
+                      ? colorScheme.surface
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  '扫码登录',
+                  style: TextStyle(
+                    color: selectedIndex == 1
+                        ? colorScheme.onSurface
+                        : colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _QrLoginForm extends StatelessWidget {
+  const _QrLoginForm({
+    required this.qrCode,
+    required this.isLoading,
+    required this.statusText,
+    required this.isExpired,
+    required this.onRefresh,
+  });
+
+  final QrCodeInfo? qrCode;
+  final bool isLoading;
+  final String statusText;
+  final bool isExpired;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surface.withValues(alpha: .92),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: colorScheme.outlineVariant),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: .06),
+            blurRadius: 24,
+            offset: const Offset(0, 14),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 18),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (isLoading)
+              Padding(
+                padding: const EdgeInsets.all(60),
+                child: CircularProgressIndicator(
+                  color: colorScheme.primary,
+                ),
+              )
+            else if (qrCode != null && qrCode!.imageUrl.isNotEmpty)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Image.network(
+                  qrCode!.imageUrl,
+                  width: 200,
+                  height: 200,
+                  fit: BoxFit.contain,
+                  errorBuilder: (_, __, ___) {
+                    return Container(
+                      width: 200,
+                      height: 200,
+                      decoration: BoxDecoration(
+                        color: colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Icon(
+                        Icons.qr_code_2_rounded,
+                        size: 80,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    );
+                  },
+                ),
+              )
+            else
+              Container(
+                width: 200,
+                height: 200,
+                decoration: BoxDecoration(
+                  color: colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Icon(
+                  Icons.qr_code_2_rounded,
+                  size: 80,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            const SizedBox(height: 24),
+            Text(
+              statusText,
+              style: textTheme.bodyMedium?.copyWith(
+                color: isExpired
+                    ? colorScheme.error
+                    : colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            if (isExpired) ...[
+              const SizedBox(height: 20),
+              GestureDetector(
+                onTap: onRefresh,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 24,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primary,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Text(
+                    '刷新二维码',
+                    style: TextStyle(
+                      color: colorScheme.onPrimary,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/pages/player_page.dart
+++ b/lib/ui/pages/player_page.dart
@@ -57,7 +57,7 @@ class _PlayerPageState extends State<PlayerPage> {
     unawaited(_setKeepScreenOn(false));
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     
-    final isTablet = AdaptiveLayout.isTablet(context);
+    final isTablet = AdaptiveLayout.isTabletByPlatform();
     if (isTablet || ThemeController.instance.landscapeEnabled) {
       SystemChrome.setPreferredOrientations(const [
         DeviceOrientation.portraitUp,


### PR DESCRIPTION
## 功能说明
本 PR 在登录页新增扫码登录功能，支持使用酷狗音乐 App 扫码登录：

1. feat: 登录页新增扫码登录功能
   - 新增 QrCodeInfo、QrCheckResult 数据模型
   - MusicApi 新增 getQrCode / checkQrStatus 接口
     （/login/qr/key、/login/qr/check）
   - AuthController 新增 loginWithSession 方法
   - LoginSession 补充 nickname、avatarUrl 字段
   - LoginPage 新增扫码 Tab UI、二维码加载与轮询确认逻辑

2. fix: 修复扫码登录二维码不显示及登录态丢失问题
   - 修正二维码状态码映射：0=等待扫码, 1=已扫码待确认,
     2=已过期, 4=登录成功（原映射相反）
   - 修复二维码图片加载 data URI 不显示的问题
   - 修复扫码登录返回缺 t1 导致 /user/detail 等接口无鉴权，
     登录后补充调用 /login/token 刷新 t1
   - 修复 sessionId 被 null 覆盖导致登录态丢失

3. fix: 修复 PlayerPage dispose 时 context 失效导致的空指针异常
   - 新增 AdaptiveLayout.isTabletByPlatform()，
     基于 PlatformDispatcher.views 计算尺寸而不依赖 context
   - dispose 改用该方法，原 isTablet(BuildContext) 保留

## 依赖说明
⚠️ 本 PR 基于并包含 #PR1（登录页设置按钮修复）的提交。
建议先合并该 PR，合并后本 PR 会自动去掉重复提交。

## 测试
- 扫码登录：二维码正常显示，扫码后状态轮询正确，登录成功并保持登录态
- 二维码过期后可刷新
- 登录后用户信息（昵称、头像）正常显示
- PlayerPage 退出时空指针异常不再出现