### PR TITLE
fix: 修复歌单详情页与云盘页顶栏滚动时内容穿透重叠

### DIFF
--- a/lib/ui/pages/cloud_drive_page.dart
+++ b/lib/ui/pages/cloud_drive_page.dart
@@ -165,6 +165,10 @@ class _CloudDrivePageState extends State<CloudDrivePage> {
                   pinned: true,
                   expandedHeight: 198,
                   surfaceTintColor: Colors.transparent,
+                  // 头部渐变顶部为半透明 primary，收缩后若 toolbar 无不透明背景，
+                  // 列表内容会透过与标题重叠。这里用 scaffoldBackgroundColor 作为
+                  // 不透明底色（与头部渐变底部一致，过渡自然），展开态被 _CloudHeader 覆盖。
+                  backgroundColor: Theme.of(context).scaffoldBackgroundColor,
                   title: const Text(
                     '云盘',
                     style: TextStyle(fontSize: 18, fontWeight: FontWeight.w800),

--- a/lib/ui/pages/playlist_detail_page.dart
+++ b/lib/ui/pages/playlist_detail_page.dart
@@ -615,6 +615,10 @@ class _PlaylistDetailPageState extends State<PlaylistDetailPage> {
                 stretch: !_isSearching,
                 expandedHeight: _isSearching ? 0 : 198,
                 surfaceTintColor: Colors.transparent,
+                // 头部渐变顶部为半透明 primary，收缩后若 toolbar 无不透明背景，
+                // 列表内容会透过与标题/操作按钮重叠。这里用 scaffoldBackgroundColor
+                // 作为不透明底色（与头部渐变底部一致，过渡自然），展开态被 _HeroHeader 覆盖。
+                backgroundColor: Theme.of(context).scaffoldBackgroundColor,
                 title: _isSearching
                     ? TextField(
                         controller: _searchController,


### PR DESCRIPTION
## Bug 描述
歌单详情页（含"我喜欢的音乐"）和云盘页向上滚动时，歌曲列表内容会
透过顶栏（标题 + 搜索/分享按钮）与顶栏元素重叠遮挡。

## 原因
两个页面的 SliverAppBar 使用 `surfaceTintColor: Colors.transparent`
且未设置 `backgroundColor`。头部渐变背景（_HeroHeader / _CloudHeader）
顶部为半透明 primary 色（18% alpha），当 flexibleSpace 随滚动收缩消失后，
pinned toolbar 只剩这层半透明背景，下方 SliverList 的歌曲行滚动时
透过半透明背景与标题、操作按钮产生视觉重叠。

## 修复方案
为 SliverAppBar 补充 `backgroundColor: scaffoldBackgroundColor`：
- **展开态**：被 flexibleSpace 的头部背景覆盖，视觉无变化
- **收缩态**：提供不透明背景遮挡列表内容，且与头部渐变底部
  （scaffoldBackgroundColor）自然衔接，过渡不突兀

## 影响范围
- lib/ui/pages/playlist_detail_page.dart（歌单/专辑详情页，"我喜欢的音乐"复用此页）
- lib/ui/pages/cloud_drive_page.dart（云盘页）

其他列表页（播放历史、已下载、本地音乐）未覆盖 surfaceTintColor，
使用 M3 默认表面色，不存在此问题。

## 测试
- 我喜欢的音乐页：上滑歌曲列表，头部收缩后顶栏有不透明背景，
  歌曲不再穿透遮挡标题/搜索/分享按钮
- 展开态头部封面渐变视觉正常
- 云盘页：上滑列表，"云盘"标题顶栏有不透明背景，列表不再穿透