### PR TITLE
fix: setState 箭头函数返回 Future 导致 debug 模式断言报错

### DIFF
--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1296,7 +1296,7 @@ class _RadioSectionState extends State<_RadioSection> {
   Future<void> _refresh() async {
     final future = _load();
     _cachedFuture = future;
-    setState(() => _future = future);
+    setState(() { _future = future; });
     await future;
   }
 


### PR DESCRIPTION
`_RadioSectionState._refresh()` 中 `setState(() => _future = future)` 使用了箭头函数，
赋值表达式 `_future = future` 会返回被赋的值（`future`，即 `Future<_RadioData>`），
Flutter 的 `setState` debug 断言检测到回调返回了 Future，抛出：

FlutterError (setState() callback argument returned a Future.
The setState() method on _RadioSectionState#55c06 was called with a closure
or method that returned a Future.)

修复方式：改为花括号体 `setState(() { _future = future; })`，无返回值，断言通过。

仅 debug 模式触发，release 模式跳过断言，表现正常。