### PR TITLE
feat: 新增车机模式（可选）及通用稳定性改进

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+.ace-tool/

--- a/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
@@ -16,7 +16,6 @@ import android.provider.MediaStore
 import android.provider.Settings
 import android.media.audiofx.BassBoost
 import android.media.audiofx.Equalizer
-import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -31,15 +30,11 @@ class MainActivity : AudioServiceActivity() {
     private var downloadReceiverRegistered = false
     private var lyricsStateReceiverRegistered = false
     private var desktopLyricsChannel: MethodChannel? = null
-    private var mediaKeyChannel: MethodChannel? = null
     private var bassBoost: BassBoost? = null
     private var bassBoostSessionId: Int? = null
     private var equalizer: Equalizer? = null
     private var equalizerSessionId: Int? = null
     private var pendingPermissionResult: MethodChannel.Result? = null
-    // MEDIA_NEXT 长按追踪：onKeyDown 时 startTracking，onKeyLongPress 标记
-    // 已长按，onKeyUp 时据此区分短按（下一首）和长按（暂停/播放）。
-    private var isMediaNextLongPressed = false
 
     companion object {
         private const val REQUEST_READ_AUDIO = 1001
@@ -95,8 +90,7 @@ class MainActivity : AudioServiceActivity() {
                 }
             }
 
-        // 车机检测：FEATURE_AUTOMOTIVE 是 Android 官方判别 Automotive 设备的 feature，
-        // 仅在车机上为 true。不使用电池/电话等启发式，避免误判插电平板。
+        // 车机检测：isAutomotive 判别车机。
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "kgka_music_hl/device")
             .setMethodCallHandler { call, result ->
                 when (call.method) {
@@ -209,10 +203,6 @@ class MainActivity : AudioServiceActivity() {
             "kgka_music_hl/desktop_lyrics"
         )
         registerLyricsStateReceiver()
-        mediaKeyChannel = MethodChannel(
-            flutterEngine.dartExecutor.binaryMessenger,
-            "kgka_music_hl/media_key"
-        )
         desktopLyricsChannel?.setMethodCallHandler { call, result ->
                 when (call.method) {
                     "checkPermission" -> {
@@ -629,44 +619,11 @@ class MainActivity : AudioServiceActivity() {
     }
 
     /// 是否为 Android Automotive 车机设备。
-    /// FEATURE_AUTOMOTIVE 是官方判别标准，国产定制 AOSP 车机若未声明则为 false。
+    /// 仅依赖官方 FEATURE_AUTOMOTIVE 标记：国产定制 AOSP 车机通常未声明，
+    /// 会判为 false，需用户在设置→个性化手动开启车机模式。
     private fun isAutomotiveDevice(): Boolean {
         return packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
     }
-
-    //region 车机方向盘媒体按键处理
-    // 拦截 KEYCODE_MEDIA_NEXT：短按切下一首，长按暂停/播放。
-    // audio_service 默认只处理短按，不识别长按，因此这里自行拦截。
-    // MEDIA_PREVIOUS 和 MEDIA_PLAY_PAUSE 仍由 audio_service 默认处理。
-    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT && event != null && event.repeatCount == 0) {
-            isMediaNextLongPressed = false
-            event.startTracking()
-            return true
-        }
-        return super.onKeyDown(keyCode, event)
-    }
-
-    override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
-            isMediaNextLongPressed = true
-            mediaKeyChannel?.invokeMethod("togglePlay", null)
-            return true
-        }
-        return super.onKeyLongPress(keyCode, event)
-    }
-
-    override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
-            if (!isMediaNextLongPressed) {
-                mediaKeyChannel?.invokeMethod("next", null)
-            }
-            isMediaNextLongPressed = false
-            return true
-        }
-        return super.onKeyUp(keyCode, event)
-    }
-    //endregion
 
     override fun onDestroy() {
         releaseEqualizer()

--- a/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
@@ -16,6 +16,7 @@ import android.provider.MediaStore
 import android.provider.Settings
 import android.media.audiofx.BassBoost
 import android.media.audiofx.Equalizer
+import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -30,11 +31,15 @@ class MainActivity : AudioServiceActivity() {
     private var downloadReceiverRegistered = false
     private var lyricsStateReceiverRegistered = false
     private var desktopLyricsChannel: MethodChannel? = null
+    private var mediaKeyChannel: MethodChannel? = null
     private var bassBoost: BassBoost? = null
     private var bassBoostSessionId: Int? = null
     private var equalizer: Equalizer? = null
     private var equalizerSessionId: Int? = null
     private var pendingPermissionResult: MethodChannel.Result? = null
+    // MEDIA_NEXT 长按追踪：onKeyDown 时 startTracking，onKeyLongPress 标记
+    // 已长按，onKeyUp 时据此区分短按（下一首）和长按（暂停/播放）。
+    private var isMediaNextLongPressed = false
 
     companion object {
         private const val REQUEST_READ_AUDIO = 1001
@@ -86,6 +91,16 @@ class MainActivity : AudioServiceActivity() {
                         }
                         result.success(null)
                     }
+                    else -> result.notImplemented()
+                }
+            }
+
+        // 车机检测：FEATURE_AUTOMOTIVE 是 Android 官方判别 Automotive 设备的 feature，
+        // 仅在车机上为 true。不使用电池/电话等启发式，避免误判插电平板。
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "kgka_music_hl/device")
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "isAutomotive" -> result.success(isAutomotiveDevice())
                     else -> result.notImplemented()
                 }
             }
@@ -194,6 +209,10 @@ class MainActivity : AudioServiceActivity() {
             "kgka_music_hl/desktop_lyrics"
         )
         registerLyricsStateReceiver()
+        mediaKeyChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "kgka_music_hl/media_key"
+        )
         desktopLyricsChannel?.setMethodCallHandler { call, result ->
                 when (call.method) {
                     "checkPermission" -> {
@@ -608,6 +627,46 @@ class MainActivity : AudioServiceActivity() {
             .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
         startActivity(installIntent)
     }
+
+    /// 是否为 Android Automotive 车机设备。
+    /// FEATURE_AUTOMOTIVE 是官方判别标准，国产定制 AOSP 车机若未声明则为 false。
+    private fun isAutomotiveDevice(): Boolean {
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+    }
+
+    //region 车机方向盘媒体按键处理
+    // 拦截 KEYCODE_MEDIA_NEXT：短按切下一首，长按暂停/播放。
+    // audio_service 默认只处理短按，不识别长按，因此这里自行拦截。
+    // MEDIA_PREVIOUS 和 MEDIA_PLAY_PAUSE 仍由 audio_service 默认处理。
+    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT && event != null && event.repeatCount == 0) {
+            isMediaNextLongPressed = false
+            event.startTracking()
+            return true
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+
+    override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
+            isMediaNextLongPressed = true
+            mediaKeyChannel?.invokeMethod("togglePlay", null)
+            return true
+        }
+        return super.onKeyLongPress(keyCode, event)
+    }
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_MEDIA_NEXT) {
+            if (!isMediaNextLongPressed) {
+                mediaKeyChannel?.invokeMethod("next", null)
+            }
+            isMediaNextLongPressed = false
+            return true
+        }
+        return super.onKeyUp(keyCode, event)
+    }
+    //endregion
 
     override fun onDestroy() {
         releaseEqualizer()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,3 +4,7 @@ android.useAndroidX=true
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false
+# Kotlin 增量编译在 Windows 跨盘符场景（项目在 D:，pub cache 在 C:）下
+# 无法计算跨盘符相对路径，导致关闭缓存时抛出 IllegalArgumentException。
+# 禁用增量编译可消除这些构建警告，对产物没有影响，仅轻微增加编译时间。
+kotlin.incremental=false

--- a/lib/controllers/player_controller.dart
+++ b/lib/controllers/player_controller.dart
@@ -41,9 +41,11 @@ class PlayerController extends ChangeNotifier {
   static const _autoResumeAfterInterruptionSettingKey =
       'settings.auto_resume_after_interruption';
   static const _playbackSpeedSettingKey = 'settings.playback_speed';
-  static const _desktopLyricsEnabledSettingKey = 'settings.desktop_lyrics_enabled';
+  static const _desktopLyricsEnabledSettingKey =
+      'settings.desktop_lyrics_enabled';
   static const _desktopLyricsSettingsKey = 'settings.desktop_lyrics_settings';
   static const _smartQualitySettingKey = 'settings.smart_quality_enabled';
+  static const _autoPlayOnStartupSettingKey = 'settings.auto_play_on_startup';
   static const _listenTimeReportInterval = Duration(minutes: 30);
   static const _listenTimeCheckInterval = Duration(minutes: 1);
   static const _defaultEqualizerLevels = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
@@ -122,7 +124,9 @@ class PlayerController extends ChangeNotifier {
       state,
     ) {
       if (state == ProcessingState.completed) {
-        unawaited(_handleCompleted());
+        if (!_isChangingSource) {
+          unawaited(_handleCompleted());
+        }
       }
     });
     _androidAudioSessionSub = audioPlayer.androidAudioSessionIdStream.listen((
@@ -178,10 +182,13 @@ class PlayerController extends ChangeNotifier {
   bool isPlaying = false;
   bool isBuffering = false;
   bool isPreparing = false;
+  bool _isChangingSource = false;
   bool addListeningTimeEnabled = true;
   AudioQuality audioQuality = AudioQuality.standard;
+
   /// 是否开启音质智能切换（播放失败时自动降级重试）。
   bool smartQualityEnabled = false;
+  bool autoPlayOnStartupEnabled = false;
   double playbackSpeed = 1.0;
   bool equalizerEnabled = false;
   List<int> equalizerLevels = List<int>.of(_defaultEqualizerLevels);
@@ -301,6 +308,7 @@ class PlayerController extends ChangeNotifier {
     _completionFallbackTimer?.cancel();
     _completedSongHash = null;
     isPreparing = true;
+    _isChangingSource = true;
     errorMessage = null;
     currentSong = song;
     if (queue != null && queue.isNotEmpty) {
@@ -328,8 +336,8 @@ class PlayerController extends ChangeNotifier {
             song.isCloudDrive
                 ? '云盘歌曲暂时没有可播放地址'
                 : song.source == SongSource.netease
-                    ? '网易云歌曲暂时没有可播放地址'
-                    : '这首歌暂时没有可播放地址',
+                ? '网易云歌曲暂时没有可播放地址'
+                : '这首歌暂时没有可播放地址',
           );
         }
         url = playUrl.url;
@@ -359,6 +367,7 @@ class PlayerController extends ChangeNotifier {
       isPreparing = false;
       notifyListeners();
     } finally {
+      _isChangingSource = false;
       if (isPreparing) {
         isPreparing = false;
         notifyListeners();
@@ -495,6 +504,15 @@ class PlayerController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 开关开机自启播放歌曲功能。
+  Future<void> setAutoPlayOnStartupEnabled(bool enabled) async {
+    if (autoPlayOnStartupEnabled == enabled) return;
+    autoPlayOnStartupEnabled = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_autoPlayOnStartupSettingKey, enabled);
+    notifyListeners();
+  }
+
   /// 读取本地播放统计。
   Future<PlaybackStats> getPlaybackStats() => _statsService.getStats();
 
@@ -504,6 +522,9 @@ class PlayerController extends ChangeNotifier {
   /// 读取播放历史。
   Future<List<Song>> getPlaybackHistory({int limit = 100}) =>
       _historyService.getHistory(limit: limit);
+
+  /// 读取播放历史总数（轻量计数，不反序列化 Song 对象）。
+  Future<int> getPlaybackHistoryCount() => _historyService.count();
 
   /// 清空播放历史。
   Future<void> clearPlaybackHistory() => _historyService.clear();
@@ -614,7 +635,8 @@ class PlayerController extends ChangeNotifier {
       try {
         final songFile = File(song.id);
         final dotIndex = songFile.path.lastIndexOf('.');
-        final lrcPath = '${dotIndex != -1 ? songFile.path.substring(0, dotIndex) : songFile.path}.lrc';
+        final lrcPath =
+            '${dotIndex != -1 ? songFile.path.substring(0, dotIndex) : songFile.path}.lrc';
         final file = File(lrcPath);
         if (await file.exists()) {
           final bytes = await file.readAsBytes();
@@ -654,7 +676,9 @@ class PlayerController extends ChangeNotifier {
               .toList(),
           ttl: const Duration(days: 30),
         );
-        if (cached != null && !listEquals(lyrics, cached.data) && currentSong?.hash == song.hash) {
+        if (cached != null &&
+            !listEquals(lyrics, cached.data) &&
+            currentSong?.hash == song.hash) {
           lyrics = cached.data;
           notifyListeners();
           _syncDesktopLyrics();
@@ -672,9 +696,11 @@ class PlayerController extends ChangeNotifier {
       }
       // 写缓存（空歌词也缓存，避免重复请求）
       if (cache != null) {
-        unawaited(cache.write(cacheKey, {
-          'lines': fresh.map((l) => l.toCache()).toList(),
-        }));
+        unawaited(
+          cache.write(cacheKey, {
+            'lines': fresh.map((l) => l.toCache()).toList(),
+          }),
+        );
       }
     } catch (_) {
       if (currentSong?.hash == song.hash && lyrics.isEmpty) {
@@ -759,6 +785,16 @@ class PlayerController extends ChangeNotifier {
         notifyListeners();
         unawaited(_audioHandler.pause());
         return;
+      }
+
+      // Windows 上 just_audio_windows 的 WinRT MediaPlayer 在触发 completed
+      // 事件时，native 回调仍在后台线程执行。若立即调用 setUrl() 加载新音源，
+      // 会与 COM 平台线程产生竞态，导致 "Lost connection to device" 进程崩溃。
+      // 延迟 100ms 让 native 层完成 completed 状态的清理，再切换到下一首。
+      if (Platform.isWindows) {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        // 延迟后重新检查状态，避免在延迟期间用户手动切歌
+        if (_completedSongHash != currentSong?.hash) return;
       }
 
       if (playbackMode == PlaybackMode.singleLoop) {
@@ -878,29 +914,22 @@ class PlayerController extends ChangeNotifier {
           // 若开启了"阻止打断"，立即恢复播放以对抗暂停。
           if (!audioInterruptionEnabled && isPlaying && currentSong != null) {
             _autoResumeTimer?.cancel();
-            _autoResumeTimer = Timer(
-              const Duration(milliseconds: 300),
-              () {
-                if (!isPlaying && currentSong != null) {
-                  unawaited(_audioHandler.play());
-                }
-              },
-            );
+            _autoResumeTimer = Timer(const Duration(milliseconds: 300), () {
+              if (!isPlaying && currentSong != null) {
+                unawaited(_audioHandler.play());
+              }
+            });
           }
         } else {
           // 打断结束：若开启了"自动恢复"或"阻止打断"，恢复播放。
-          if ((autoResumeAfterInterruption ||
-                  (!audioInterruptionEnabled)) &&
+          if ((autoResumeAfterInterruption || (!audioInterruptionEnabled)) &&
               currentSong != null) {
             _autoResumeTimer?.cancel();
-            _autoResumeTimer = Timer(
-              const Duration(milliseconds: 500),
-              () {
-                if (!isPlaying && currentSong != null) {
-                  unawaited(_audioHandler.play());
-                }
-              },
-            );
+            _autoResumeTimer = Timer(const Duration(milliseconds: 500), () {
+              if (!isPlaying && currentSong != null) {
+                unawaited(_audioHandler.play());
+              }
+            });
           }
         }
       });
@@ -911,14 +940,11 @@ class PlayerController extends ChangeNotifier {
         }
         if (autoResumeAfterInterruption && currentSong != null) {
           _autoResumeTimer?.cancel();
-          _autoResumeTimer = Timer(
-            const Duration(milliseconds: 500),
-            () {
-              if (!isPlaying && currentSong != null) {
-                unawaited(_audioHandler.play());
-              }
-            },
-          );
+          _autoResumeTimer = Timer(const Duration(milliseconds: 500), () {
+            if (!isPlaying && currentSong != null) {
+              unawaited(_audioHandler.play());
+            }
+          });
         }
       });
     } catch (_) {
@@ -1014,7 +1040,10 @@ class PlayerController extends ChangeNotifier {
 
     final song = currentSong;
     if (song == null) return;
-    final shown = await _desktopLyrics.show(title: song.title, artist: song.artist);
+    final shown = await _desktopLyrics.show(
+      title: song.title,
+      artist: song.artist,
+    );
     if (shown) {
       _syncDesktopLyrics();
       _syncDesktopPlayState();
@@ -1118,10 +1147,15 @@ class PlayerController extends ChangeNotifier {
     return null;
   }
 
-  Future<void> updateDesktopLyricsSettings(DesktopLyricsSettings settings) async {
+  Future<void> updateDesktopLyricsSettings(
+    DesktopLyricsSettings settings,
+  ) async {
     desktopLyricsSettings = settings;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_desktopLyricsSettingsKey, jsonEncode(settings.toMap()));
+    await prefs.setString(
+      _desktopLyricsSettingsKey,
+      jsonEncode(settings.toMap()),
+    );
     notifyListeners();
     await _desktopLyrics.updateSettings(settings);
   }
@@ -1248,6 +1282,8 @@ class PlayerController extends ChangeNotifier {
     );
     smartQualityEnabled =
         prefs.getBool(_smartQualitySettingKey) ?? smartQualityEnabled;
+    autoPlayOnStartupEnabled =
+        prefs.getBool(_autoPlayOnStartupSettingKey) ?? autoPlayOnStartupEnabled;
     equalizerEnabled =
         prefs.getBool(_equalizerEnabledSettingKey) ?? equalizerEnabled;
     equalizerPresetName =
@@ -1262,12 +1298,11 @@ class PlayerController extends ChangeNotifier {
         prefs.getDouble(_bassBoostStrengthSettingKey) ?? bassBoostStrength;
     audioInterruptionEnabled =
         prefs.getBool(_audioInterruptionEnabledSettingKey) ??
-            audioInterruptionEnabled;
+        audioInterruptionEnabled;
     autoResumeAfterInterruption =
         prefs.getBool(_autoResumeAfterInterruptionSettingKey) ??
-            autoResumeAfterInterruption;
-    playbackSpeed =
-        prefs.getDouble(_playbackSpeedSettingKey) ?? playbackSpeed;
+        autoResumeAfterInterruption;
+    playbackSpeed = prefs.getDouble(_playbackSpeedSettingKey) ?? playbackSpeed;
     desktopLyricsEnabled =
         prefs.getBool(_desktopLyricsEnabledSettingKey) ?? desktopLyricsEnabled;
     final dlSettingsRaw = prefs.getString(_desktopLyricsSettingsKey);

--- a/lib/controllers/theme_controller.dart
+++ b/lib/controllers/theme_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../services/device_info_service.dart';
 
 /// 全局个性化设置控制器。
 ///
@@ -27,6 +28,10 @@ class ThemeController extends ChangeNotifier {
   static const _bgImagePathKey = 'theme.bg_image_path';
   static const _bgOpacityKey = 'theme.bg_opacity';
   static const _landscapeEnabledKey = 'theme.landscape_enabled';
+  static const _carModeEnabledKey = 'theme.car_mode_enabled';
+
+  /// 车机模式下文字放大倍数（远距离观看更清晰）。
+  static const double carModeFontScaleFactor = 1.12;
 
   /// 预设种子色列表。
   static const presetColors = <_PresetColor>[
@@ -45,6 +50,9 @@ class ThemeController extends ChangeNotifier {
   String? _backgroundImagePath;
   double _backgroundOpacity = 0.15;
   bool _landscapeEnabled = false;
+  bool _carModeEnabled = false;
+  // 车机检测结果缓存（设备不变，启动时检测一次）。
+  bool _isAutomotiveDevice = false;
 
   bool? _lastAppliedIsTablet;
   bool? _lastAppliedLandscapeEnabled;
@@ -54,9 +62,18 @@ class ThemeController extends ChangeNotifier {
   String? get backgroundImagePath => _backgroundImagePath;
   double get backgroundOpacity => _backgroundOpacity;
   bool get landscapeEnabled => _landscapeEnabled;
+  bool get carModeEnabled => _carModeEnabled;
+  bool get isAutomotiveDevice => _isAutomotiveDevice;
 
   /// 是否使用了非默认种子色。
   bool get hasCustomSeedColor => _seedColor != const Color(0xFF1478FF);
+
+  /// 检测是否为 Android Automotive 车机并缓存结果。
+  /// 设备类型不变，启动时调用一次即可。须在 [load] 之前调用，
+  /// 以便首次安装时据检测结果决定车机模式默认值。
+  Future<void> detectAutomotive(DeviceInfoService deviceInfo) async {
+    _isAutomotiveDevice = await deviceInfo.isAutomotive();
+  }
 
   /// 加载持久化设置。
   Future<void> load() async {
@@ -68,6 +85,13 @@ class ThemeController extends ChangeNotifier {
     _backgroundEnabled = prefs.getBool(_bgEnabledKey) ?? false;
     _backgroundImagePath = prefs.getString(_bgImagePathKey);
     _landscapeEnabled = prefs.getBool(_landscapeEnabledKey) ?? false;
+    // 首次安装（键不存在）：检测到车机则默认开启车机模式；
+    // 否则默认关闭。用户手动开关过后键一定存在，永不覆盖用户选择。
+    if (prefs.containsKey(_carModeEnabledKey)) {
+      _carModeEnabled = prefs.getBool(_carModeEnabledKey) ?? false;
+    } else {
+      _carModeEnabled = _isAutomotiveDevice;
+    }
     final opacity = prefs.getDouble(_bgOpacityKey);
     if (opacity != null) {
       _backgroundOpacity = opacity.clamp(0.0, 0.8);
@@ -100,6 +124,16 @@ class ThemeController extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_landscapeEnabledKey, enabled);
     applyOrientations(isTablet);
+    notifyListeners();
+  }
+
+  /// 开启/关闭车机模式：横屏时启用左侧播放面板 + 顶栏布局，并放大文字。
+  /// 关闭时回到普通横屏（NavigationRail），竖屏始终不受影响。
+  Future<void> setCarModeEnabled(bool enabled) async {
+    if (_carModeEnabled == enabled) return;
+    _carModeEnabled = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_carModeEnabledKey, enabled);
     notifyListeners();
   }
 

--- a/lib/controllers/theme_controller.dart
+++ b/lib/controllers/theme_controller.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/device_info_service.dart';
+import '../ui/adaptive_layout.dart';
 
 /// 全局个性化设置控制器。
 ///
@@ -56,6 +57,7 @@ class ThemeController extends ChangeNotifier {
 
   bool? _lastAppliedIsTablet;
   bool? _lastAppliedLandscapeEnabled;
+  bool? _lastAppliedCarModeEnabled;
 
   Color get seedColor => _seedColor;
   bool get backgroundEnabled => _backgroundEnabled;
@@ -96,6 +98,7 @@ class ThemeController extends ChangeNotifier {
     if (opacity != null) {
       _backgroundOpacity = opacity.clamp(0.0, 0.8);
     }
+    applyOrientations(AdaptiveLayout.isTabletByPlatform());
     notifyListeners();
   }
 
@@ -134,19 +137,22 @@ class ThemeController extends ChangeNotifier {
     _carModeEnabled = enabled;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_carModeEnabledKey, enabled);
+    applyOrientations(AdaptiveLayout.isTabletByPlatform());
     notifyListeners();
   }
 
   /// 动态应用屏幕方向锁定/解锁。
   void applyOrientations(bool isTablet) {
     if (_lastAppliedIsTablet == isTablet &&
-        _lastAppliedLandscapeEnabled == _landscapeEnabled) {
+        _lastAppliedLandscapeEnabled == _landscapeEnabled &&
+        _lastAppliedCarModeEnabled == _carModeEnabled) {
       return;
     }
     _lastAppliedIsTablet = isTablet;
     _lastAppliedLandscapeEnabled = _landscapeEnabled;
+    _lastAppliedCarModeEnabled = _carModeEnabled;
 
-    if (isTablet || _landscapeEnabled) {
+    if (isTablet || _landscapeEnabled || _carModeEnabled) {
       SystemChrome.setPreferredOrientations(const [
         DeviceOrientation.portraitUp,
         DeviceOrientation.portraitDown,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'controllers/local_music_controller.dart';
 import 'controllers/theme_controller.dart';
 import 'core/api_client.dart';
 import 'services/cache_service.dart';
+import 'services/device_info_service.dart';
 import 'services/download_service.dart';
 import 'services/music_audio_handler.dart';
 import 'services/music_api.dart';
@@ -37,6 +38,8 @@ Future<void> main() async {
   );
 
   final themeController = ThemeController();
+  // 先检测车机，再加载设置：首次安装时据检测结果决定车机模式默认值。
+  await themeController.detectAutomotive(const DeviceInfoService());
   await themeController.load();
 
   runApp(KaMusicApp(

--- a/lib/services/device_info_service.dart
+++ b/lib/services/device_info_service.dart
@@ -15,8 +15,6 @@ class DeviceInfoService {
   }
 
   /// 是否为 Android Automotive 车机。
-  ///
-  /// 仅判断 FEATURE_AUTOMOTIVE，不会误判插电平板。
   Future<bool> isAutomotive() async {
     if (!isSupportedPlatform) return false;
     try {
@@ -27,4 +25,5 @@ class DeviceInfoService {
       return false;
     }
   }
+
 }

--- a/lib/services/device_info_service.dart
+++ b/lib/services/device_info_service.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// 设备类型检测服务。
+///
+/// 通过 MethodChannel 调用原生层判断是否为 Android Automotive 车机。
+/// 非 Android 平台恒返回 false。
+class DeviceInfoService {
+  const DeviceInfoService();
+
+  static const MethodChannel _channel = MethodChannel('kgka_music_hl/device');
+
+  static bool get isSupportedPlatform {
+    return !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+  }
+
+  /// 是否为 Android Automotive 车机。
+  ///
+  /// 仅判断 FEATURE_AUTOMOTIVE，不会误判插电平板。
+  Future<bool> isAutomotive() async {
+    if (!isSupportedPlatform) return false;
+    try {
+      return await _channel.invokeMethod<bool>('isAutomotive') ?? false;
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+}

--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -55,6 +55,21 @@ class PlaybackHistoryService {
     }
   }
 
+  /// 读取历史记录总数（仅解析 JSON 长度，不反序列化 Song 对象）。
+  ///
+  /// 用于 UI 上的计数展示，避免为了取 length 而反序列化全部 Song。
+  /// 返回值受 [_maxRecords] 上限约束。
+  Future<int> count() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return 0;
+    try {
+      return (jsonDecode(raw) as List).length;
+    } catch (_) {
+      return 0;
+    }
+  }
+
   /// 清空播放历史。
   Future<void> clear() async {
     final prefs = await SharedPreferences.getInstance();

--- a/lib/ui/adaptive_layout.dart
+++ b/lib/ui/adaptive_layout.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../controllers/theme_controller.dart';
+
 /// 自适应布局工具类。
 ///
 /// 平板检测基于 Material Design 的 breakpoint：
@@ -53,8 +55,18 @@ class AdaptiveLayout {
   /// - 600 ≤ 宽度 < 1200：限制 [tabletMaxWidth]
   /// - 宽度 ≥ 1200：限制 [wideMaxWidth]
   static double contentMaxWidthFor(BuildContext context) {
-    final width = MediaQuery.sizeOf(context).width;
+    final size = MediaQuery.sizeOf(context);
+    final width = size.width;
     if (width < 600) return double.infinity;
+
+    // 取消宽度限制是车机横屏专属（让内容铺满宽屏）；
+    // 普通横屏/平板仍按原逻辑限制内容最大宽度，避免行宽过长难读。
+    final isCarLandscape =
+        size.width > size.height && ThemeController.instance.carModeEnabled;
+    if (isCarLandscape) {
+      return double.infinity;
+    }
+
     if (width < 1200) return tabletMaxWidth;
     return wideMaxWidth;
   }

--- a/lib/ui/pages/album_shop_page.dart
+++ b/lib/ui/pages/album_shop_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../controllers/auth_controller.dart';
 import '../../controllers/player_controller.dart';
+import '../../controllers/theme_controller.dart';
 import '../../models/music_models.dart';
 import '../../services/music_api.dart';
 import '../widgets/artwork.dart';
@@ -93,6 +94,13 @@ class _AlbumShopPageState extends State<AlbumShopPage> {
   @override
   Widget build(BuildContext context) {
     final bottomInset = MediaQuery.paddingOf(context).bottom;
+    final size = MediaQuery.sizeOf(context);
+    // 多列自适应是车机横屏专属；普通横屏/竖屏保持原项目固定 2 列。
+    final isCarLandscape =
+        size.width > size.height && ThemeController.instance.carModeEnabled;
+    final crossAxisCount = isCarLandscape
+        ? (size.width / 180).floor().clamp(2, 5)
+        : 2;
 
     return Scaffold(
       extendBody: true,
@@ -111,8 +119,8 @@ class _AlbumShopPageState extends State<AlbumShopPage> {
               SliverPadding(
                 padding: const EdgeInsets.fromLTRB(18, 8, 18, 12),
                 sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: crossAxisCount,
                     mainAxisSpacing: 14,
                     crossAxisSpacing: 14,
                     childAspectRatio: 0.72,

--- a/lib/ui/pages/app_shell.dart
+++ b/lib/ui/pages/app_shell.dart
@@ -47,31 +47,6 @@ class _AppShellState extends State<AppShell> {
   var _lastHomeTab = 1; // Tracks the last active Home sub-tab (1 for Recommend, 2 for Radio)
   final _navigatorKey = GlobalKey<NavigatorState>();
 
-  // 车机方向盘 MEDIA_NEXT 按键通道：短按下一首，长按暂停/播放。
-  // 由 MainActivity.kt 的 onKeyDown/onKeyLongPress/onKeyUp 触发。
-  static const _mediaKeyChannel = MethodChannel('kgka_music_hl/media_key');
-
-  @override
-  void initState() {
-    super.initState();
-    _mediaKeyChannel.setMethodCallHandler((call) async {
-      switch (call.method) {
-        case 'next':
-          widget.player.next();
-          break;
-        case 'togglePlay':
-          widget.player.togglePlay();
-          break;
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _mediaKeyChannel.setMethodCallHandler(null);
-    super.dispose();
-  }
-
   int _getPortraitIndex() {
     return _index == 0 ? 1 : 0;
   }

--- a/lib/ui/pages/app_shell.dart
+++ b/lib/ui/pages/app_shell.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../controllers/auth_controller.dart';
 import '../../controllers/download_controller.dart';
@@ -10,9 +11,12 @@ import '../../controllers/local_music_controller.dart';
 import '../../services/cache_service.dart';
 import '../../services/music_api.dart';
 import '../widgets/mini_player.dart';
+import '../widgets/car_left_player_panel.dart';
 import '../adaptive_layout.dart';
 import 'home_page.dart';
 import 'library_page.dart';
+import 'search_page.dart';
+import 'settings_page.dart';
 
 class AppShell extends StatefulWidget {
   const AppShell({
@@ -39,23 +43,43 @@ class AppShell extends StatefulWidget {
 }
 
 class _AppShellState extends State<AppShell> {
-  var _index = 0;
-  late final List<Widget> _pages;
+  var _index = 1; // Default to '推荐' tab (index 1) in landscape
+  var _lastHomeTab = 1; // Tracks the last active Home sub-tab (1 for Recommend, 2 for Radio)
+  final _navigatorKey = GlobalKey<NavigatorState>();
+
+  // 车机方向盘 MEDIA_NEXT 按键通道：短按下一首，长按暂停/播放。
+  // 由 MainActivity.kt 的 onKeyDown/onKeyLongPress/onKeyUp 触发。
+  static const _mediaKeyChannel = MethodChannel('kgka_music_hl/media_key');
 
   @override
   void initState() {
     super.initState();
-    _pages = [
-      HomePage(api: widget.api, auth: widget.auth, player: widget.player, cache: widget.cache),
-      LibraryPage(
-        api: widget.api,
-        auth: widget.auth,
-        player: widget.player,
-        downloads: widget.downloads,
-        theme: widget.theme,
-        localMusic: widget.localMusic,
-      ),
-    ];
+    _mediaKeyChannel.setMethodCallHandler((call) async {
+      switch (call.method) {
+        case 'next':
+          widget.player.next();
+          break;
+        case 'togglePlay':
+          widget.player.togglePlay();
+          break;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _mediaKeyChannel.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  int _getPortraitIndex() {
+    return _index == 0 ? 1 : 0;
+  }
+
+  void _setPortraitIndex(int index) {
+    setState(() {
+      _index = index == 0 ? _lastHomeTab : 0;
+    });
   }
 
   @override
@@ -63,21 +87,158 @@ class _AppShellState extends State<AppShell> {
     final bottomInset = MediaQuery.paddingOf(context).bottom;
     final colorScheme = Theme.of(context).colorScheme;
     final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width > size.height;
+
+    // 车机布局：仅在横屏且开启车机模式时启用（左侧播放面板 + 顶栏）。
+    // 关闭时回到普通布局（宽屏用 NavigationRail），与原项目行为一致；
+    // 平板横屏适配留给上游后续开发。
+    if (isLandscape && widget.theme.carModeEnabled) {
+      // 车机模式下文字相对放大（保留系统无障碍设置）。
+      final baseTextScaler = MediaQuery.textScalerOf(context);
+      final scaledTextScaler = _RelativeTextScaler(
+        base: baseTextScaler,
+        multiplier: ThemeController.carModeFontScaleFactor,
+      );
+      return MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: scaledTextScaler),
+        child: PopScope(
+          // 拦截 Android 返回键：先尝试 pop 内层 Navigator（搜索/设置/歌单等
+          // push 到内层 Navigator 的页面），内层无法 pop 时才退出应用。
+          // 不加 PopScope 会导致返回键只 pop root Navigator（只有一个 AppShell
+          // route），从歌单页面返回直接退出应用。
+          canPop: false,
+          onPopInvokedWithResult: (didPop, _) {
+            if (didPop) return;
+            final nav = _navigatorKey.currentState;
+            if (nav != null && nav.canPop()) {
+              nav.pop();
+            } else {
+              SystemNavigator.pop();
+            }
+          },
+          child: Scaffold(
+            body: Row(
+              children: [
+                // ExcludeSemantics 规避 CarLeftPlayerPanel 频繁响应 player 更新
+                // 导致的 Windows AXTree 竞态崩溃（Flutter Windows 引擎 bug）
+                ExcludeSemantics(
+                  child: CarLeftPlayerPanel(
+                    player: widget.player,
+                    auth: widget.auth,
+                  ),
+                ),
+                const VerticalDivider(width: 1, thickness: 1),
+                Expanded(
+                  child: Navigator(
+                    key: _navigatorKey,
+                    onGenerateRoute: (settings) {
+                      return MaterialPageRoute(
+                        builder: (navContext) {
+                          final homePage = HomePage(
+                            api: widget.api,
+                            auth: widget.auth,
+                            player: widget.player,
+                            cache: widget.cache,
+                            theme: widget.theme,
+                            downloads: widget.downloads,
+                            localMusic: widget.localMusic,
+                            sectionIndex: _index == 2 ? 1 : 0,
+                            onTabSwitch: (index) {
+                              setState(() {
+                                _index = index;
+                                if (index == 1 || index == 2) {
+                                  _lastHomeTab = index;
+                                }
+                              });
+                            },
+                          );
+
+                          final libraryPage = LibraryPage(
+                            api: widget.api,
+                            auth: widget.auth,
+                            player: widget.player,
+                            downloads: widget.downloads,
+                            theme: widget.theme,
+                            localMusic: widget.localMusic,
+                          );
+
+                          final pages = [homePage, libraryPage];
+                          final activePageIndex = _index == 0 ? 1 : 0;
+
+                          return Scaffold(
+                            body: Column(
+                              children: [
+                                _buildCarTopNavBar(navContext, colorScheme),
+                                const Divider(height: 1),
+                                Expanded(
+                                  child: _LazyIndexedStack(
+                                    index: activePageIndex,
+                                    children: pages,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Original Portrait Layout
     final useNavRail = size.width >= 720;
+    final portraitIndex = _getPortraitIndex();
+
+    final homePage = HomePage(
+      api: widget.api,
+      auth: widget.auth,
+      player: widget.player,
+      cache: widget.cache,
+      theme: widget.theme,
+      downloads: widget.downloads,
+      localMusic: widget.localMusic,
+      sectionIndex: _index == 2 ? 1 : 0,
+      onTabSwitch: (index) {
+        setState(() {
+          _index = index;
+          if (index == 1 || index == 2) {
+            _lastHomeTab = index;
+          }
+        });
+      },
+    );
+
+    final libraryPage = LibraryPage(
+      api: widget.api,
+      auth: widget.auth,
+      player: widget.player,
+      downloads: widget.downloads,
+      theme: widget.theme,
+      localMusic: widget.localMusic,
+    );
+
+    final pages = [homePage, libraryPage];
 
     Widget mainContent = Stack(
       children: [
         Positioned.fill(
-          child: IndexedStack(index: _index, children: _pages),
+          child: _LazyIndexedStack(
+            index: portraitIndex,
+            children: pages,
+          ),
         ),
         Positioned(
           left: 0,
           right: 0,
-          bottom: bottomInset + (useNavRail ? 16 : kBottomNavigationBarHeight + 10),
-          child: MiniPlayer(
-            player: widget.player,
-            auth: widget.auth,
-          ),
+          bottom:
+              bottomInset + (useNavRail ? 16 : kBottomNavigationBarHeight + 10),
+          child: MiniPlayer(player: widget.player, auth: widget.auth),
         ),
       ],
     );
@@ -86,12 +247,14 @@ class _AppShellState extends State<AppShell> {
       mainContent = Row(
         children: [
           NavigationRail(
-            selectedIndex: _index,
-            onDestinationSelected: (value) => setState(() => _index = value),
+            selectedIndex: portraitIndex,
+            onDestinationSelected: _setPortraitIndex,
             backgroundColor: colorScheme.surfaceContainerLow,
             labelType: NavigationRailLabelType.all,
             selectedIconTheme: IconThemeData(color: colorScheme.primary),
-            unselectedIconTheme: IconThemeData(color: colorScheme.onSurfaceVariant),
+            unselectedIconTheme: IconThemeData(
+              color: colorScheme.onSurfaceVariant,
+            ),
             selectedLabelTextStyle: TextStyle(
               color: colorScheme.primary,
               fontWeight: FontWeight.w800,
@@ -121,9 +284,7 @@ class _AppShellState extends State<AppShell> {
 
     return Scaffold(
       extendBody: true,
-      body: AdaptiveContentPadding(
-        child: mainContent,
-      ),
+      body: AdaptiveContentPadding(child: mainContent),
       bottomNavigationBar: useNavRail
           ? null
           : ClipRect(
@@ -132,23 +293,33 @@ class _AppShellState extends State<AppShell> {
                 child: Container(
                   decoration: BoxDecoration(
                     color: Theme.of(context).brightness == Brightness.dark
-                        ? colorScheme.surfaceContainerHighest.withValues(alpha: .72)
-                        : colorScheme.surfaceContainerHighest.withValues(alpha: .64),
+                        ? colorScheme.surfaceContainerHighest.withValues(
+                            alpha: .72,
+                          )
+                        : colorScheme.surfaceContainerHighest.withValues(
+                            alpha: .64,
+                          ),
                     border: Border(
                       top: BorderSide(
-                        color: colorScheme.outlineVariant.withValues(alpha: .38),
+                        color: colorScheme.outlineVariant.withValues(
+                          alpha: .38,
+                        ),
                       ),
                     ),
                   ),
                   child: BottomNavigationBar(
-                    currentIndex: _index,
-                    onTap: (value) => setState(() => _index = value),
+                    currentIndex: portraitIndex,
+                    onTap: _setPortraitIndex,
                     backgroundColor: Colors.transparent,
                     elevation: 0,
                     selectedItemColor: colorScheme.primary,
                     unselectedItemColor: colorScheme.onSurface,
-                    selectedLabelStyle: const TextStyle(fontWeight: FontWeight.w800),
-                    unselectedLabelStyle: const TextStyle(fontWeight: FontWeight.w600),
+                    selectedLabelStyle: const TextStyle(
+                      fontWeight: FontWeight.w800,
+                    ),
+                    unselectedLabelStyle: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                    ),
                     items: const [
                       BottomNavigationBarItem(
                         icon: Icon(Icons.home_outlined),
@@ -167,4 +338,204 @@ class _AppShellState extends State<AppShell> {
             ),
     );
   }
+
+  Widget _buildCarTopNavBar(BuildContext context, ColorScheme colorScheme) {
+    final tabs = ['我的', '推荐', '电台'];
+    final topInset = MediaQuery.paddingOf(context).top;
+    return Container(
+      // 顶部加上状态栏高度，避免导航栏内容被状态栏遮挡
+      padding: EdgeInsets.fromLTRB(16, topInset, 16, 0),
+      height: 72 + topInset, // Increased from 64
+      child: Row(
+        children: [
+          // Search Pill Button
+          GestureDetector(
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => SearchPage(
+                  api: widget.api,
+                  auth: widget.auth,
+                  player: widget.player,
+                ),
+              ),
+            ),
+            child: Container(
+              height: 46, // Increased from 38
+              padding: const EdgeInsets.symmetric(horizontal: 20), // Increased from 16
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest.withValues(
+                  alpha: .54,
+                ),
+                borderRadius: BorderRadius.circular(23), // Increased from 19 (height/2)
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.search_rounded,
+                    color: colorScheme.onSurfaceVariant,
+                    size: 22, // Increased from 20
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '搜索',
+                    style: TextStyle(
+                      color: colorScheme.onSurfaceVariant,
+                      fontSize: 16, // Increased from default
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 32), // Increased from 24
+          // Choice Chip Tabs
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  for (final entry in tabs.indexed)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 10), // Increased from 6
+                      child: ChoiceChip(
+                        showCheckmark: false,
+                        label: Text(
+                          entry.$2,
+                          style: TextStyle(
+                            fontSize: 17, // Increased from default
+                            fontWeight: _index == entry.$1
+                                ? FontWeight.w900
+                                : FontWeight.w600,
+                          ),
+                        ),
+                        selected: _index == entry.$1,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setState(() {
+                              _index = entry.$1;
+                              if (entry.$1 == 1 || entry.$1 == 2) {
+                                _lastHomeTab = entry.$1;
+                              }
+                            });
+                          }
+                        },
+                        selectedColor: colorScheme.primary.withValues(
+                          alpha: 0.18,
+                        ),
+                        labelStyle: TextStyle(
+                          color: _index == entry.$1
+                              ? colorScheme.primary
+                              : colorScheme.onSurfaceVariant,
+                        ),
+                        backgroundColor: Colors.transparent,
+                        side: BorderSide.none,
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10), // Added explicit padding
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12), // Added explicit shape for larger tap area
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          // Settings Icon
+          IconButton(
+            tooltip: '设置',
+            iconSize: 28, // Increased iconSize from default (24)
+            icon: const Icon(Icons.settings_rounded),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => SettingsPage(
+                    api: widget.api,
+                    auth: widget.auth,
+                    player: widget.player,
+                    theme: widget.theme,
+                    downloads: widget.downloads,
+                    cache: widget.cache,
+                    localMusic: widget.localMusic,
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 只在首次被选中时才构建对应 child 的 [IndexedStack]。
+///
+/// 普通 IndexedStack 会一次性构建全部 children，导致所有页面
+/// 都在 initState 中发起网络请求。这里通过懒构建
+/// 保证只有被访问过的 tab 才会真正初始化，避免重复请求与重复监听。
+class _LazyIndexedStack extends StatefulWidget {
+  const _LazyIndexedStack({required this.index, required this.children});
+
+  final int index;
+  final List<Widget> children;
+
+  @override
+  State<_LazyIndexedStack> createState() => _LazyIndexedStackState();
+}
+
+class _LazyIndexedStackState extends State<_LazyIndexedStack> {
+  final _built = <int>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _built.add(widget.index);
+  }
+
+  @override
+  void didUpdateWidget(covariant _LazyIndexedStack oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _built.add(widget.index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IndexedStack(
+      index: widget.index,
+      children: [
+        for (var i = 0; i < widget.children.length; i++)
+          _built.contains(i) ? widget.children[i] : const SizedBox.shrink(),
+      ],
+    );
+  }
+}
+
+/// 在已有 [TextScaler] 基础上再乘固定倍数（Flutter 内置 TextScaler 无 `*` 运算符）。
+class _RelativeTextScaler extends TextScaler {
+  const _RelativeTextScaler({required this.base, required this.multiplier});
+
+  final TextScaler base;
+  final double multiplier;
+
+  @override
+  double scale(double fontSize) => base.scale(fontSize) * multiplier;
+
+  @override
+  double get textScaleFactor {
+    // ignore: deprecated_member_use
+    final baseFactor = base.textScaleFactor;
+    return baseFactor * multiplier;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _RelativeTextScaler &&
+          base == other.base &&
+          multiplier == other.multiplier;
+
+  @override
+  int get hashCode => Object.hash(base, multiplier);
+
+  @override
+  String toString() => '$base × $multiplier';
 }

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../../config/app_config.dart';
@@ -17,6 +19,11 @@ import 'album_shop_page.dart';
 import 'artist_detail_page.dart';
 import 'playlist_detail_page.dart';
 import 'search_page.dart';
+import '../../controllers/theme_controller.dart';
+import '../../controllers/download_controller.dart';
+import '../../controllers/local_music_controller.dart';
+import 'playback_history_page.dart';
+import 'settings_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({
@@ -25,12 +32,22 @@ class HomePage extends StatefulWidget {
     required this.auth,
     required this.player,
     required this.cache,
+    required this.theme,
+    required this.downloads,
+    required this.localMusic,
+    this.sectionIndex = 0,
+    this.onTabSwitch,
   });
 
   final MusicApi api;
   final AuthController auth;
   final PlayerController player;
   final CacheService cache;
+  final ThemeController theme;
+  final DownloadController downloads;
+  final LocalMusicController localMusic;
+  final int sectionIndex;
+  final ValueChanged<int>? onTabSwitch;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -38,6 +55,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   static _HomeData? _cachedData;
+  static bool _hasAutoPlayed = false;
 
   Future<_HomeData>? _future;
   late final AppUpdateService _updateService;
@@ -49,10 +67,12 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    _sectionIndex = widget.sectionIndex;
     _updateService = AppUpdateService(widget.api);
     final cached = _cachedData;
     if (cached != null) {
       _future = Future.value(cached);
+      _checkAndAutoPlay(cached);
       // 有缓存数据，立即显示并后台静默刷新
       _silentRefresh();
     } else if (!widget.auth.isRestoring) {
@@ -63,6 +83,14 @@ class _HomePageState extends State<HomePage> {
     widget.auth.addListener(_handleAuthChanged);
     if (AppUpdateService.isSupportedPlatform) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _checkForUpdates());
+    }
+  }
+
+  @override
+  void didUpdateWidget(HomePage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sectionIndex != widget.sectionIndex) {
+      _sectionIndex = widget.sectionIndex;
     }
   }
 
@@ -81,6 +109,34 @@ class _HomePageState extends State<HomePage> {
       setState(() {
         _future = _load();
       });
+    }
+  }
+
+  void _checkAndAutoPlay(_HomeData data) {
+    if (widget.player.autoPlayOnStartupEnabled &&
+        !_hasAutoPlayed &&
+        widget.player.currentSong == null) {
+      _hasAutoPlayed = true;
+      final songs = data.daily.songs;
+      if (songs.isNotEmpty) {
+        // 必须推迟到首帧构建完成后执行：_checkAndAutoPlay 会在 initState
+        // 阶段被同步调用，此时直接调用 playSong 会触发 notifyListeners()，
+        // 违反 Flutter "build 阶段不能触发 setState/notifyListeners" 规则。
+        // 叠加 Windows 平台 just_audio 的 WinRT MediaPlayer COM 线程在应用
+        // 启动早期尚未完全就绪，立即 setUrl()/play() 会与 UI 渲染竞争，
+        // 导致 "Lost connection to device" 进程崩溃。
+        // Windows 上额外延迟 300ms 让 native 层完全稳定后再启动播放。
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          final delay = Platform.isWindows
+              ? const Duration(milliseconds: 300)
+              : Duration.zero;
+          Future<void>.delayed(delay, () {
+            if (!mounted) return;
+            widget.player.playSong(songs.first, queue: songs);
+          });
+        });
+      }
     }
   }
 
@@ -108,6 +164,7 @@ class _HomePageState extends State<HomePage> {
         'albums': data.albums.map((a) => a.toCache()).toList(),
       });
       if (!mounted) return;
+      _checkAndAutoPlay(data);
       setState(() {
         _future = Future.value(data);
       });
@@ -133,6 +190,7 @@ class _HomePageState extends State<HomePage> {
       'playlists': data.playlists.map((p) => p.toCache()).toList(),
       'albums': data.albums.map((a) => a.toCache()).toList(),
     });
+    _checkAndAutoPlay(data);
     return data;
   }
 
@@ -146,6 +204,7 @@ class _HomePageState extends State<HomePage> {
     if (cached != null) {
       final data = _homeDataFromCache(cached.data);
       _cachedData = data;
+      _checkAndAutoPlay(data);
       setState(() {
         _future = Future.value(data);
       });
@@ -271,6 +330,22 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  void _openSettings() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => SettingsPage(
+          api: widget.api,
+          auth: widget.auth,
+          player: widget.player,
+          theme: widget.theme,
+          downloads: widget.downloads,
+          cache: widget.cache,
+          localMusic: widget.localMusic,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<_HomeData>(
@@ -302,7 +377,12 @@ class _HomePageState extends State<HomePage> {
                     albums: data.albums,
                     sectionIndex: _sectionIndex,
                     onSectionChanged: (value) {
-                      setState(() => _sectionIndex = value);
+                      if (value == -1) {
+                        widget.onTabSwitch?.call(0); // Switch to My tab
+                      } else {
+                        setState(() => _sectionIndex = value);
+                        widget.onTabSwitch?.call(value == 0 ? 1 : 2);
+                      }
                     },
                     onDailyPlay: () {
                       final songs = data.daily.songs;
@@ -322,6 +402,7 @@ class _HomePageState extends State<HomePage> {
                     onUpdateClose: () {
                       setState(() => _updateBannerDismissed = true);
                     },
+                    onSettingsTap: _openSettings,
                   ),
                 ),
                 SliverToBoxAdapter(
@@ -382,6 +463,7 @@ class _RecommendHeader extends StatelessWidget {
     required this.updateVersion,
     required this.onUpdateTap,
     required this.onUpdateClose,
+    required this.onSettingsTap,
   });
 
   final AuthController auth;
@@ -396,10 +478,22 @@ class _RecommendHeader extends StatelessWidget {
   final AppVersionInfo? updateVersion;
   final VoidCallback onUpdateTap;
   final VoidCallback onUpdateClose;
+  final VoidCallback onSettingsTap;
 
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width > size.height;
+    // 车机模式专属样式仅在开启时生效，普通横屏不受影响。
+    final isCarMode = isLandscape && ThemeController.instance.carModeEnabled;
+    // 车机宽屏：三个快捷入口在卡片右侧；车机非宽屏：入口在卡片下方。
+    final isUltraWide =
+        isCarMode &&
+        size.width >= 1150 &&
+        size.height >= 600 &&
+        (size.width / size.height) > 2.0;
+
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: LinearGradient(
@@ -414,23 +508,26 @@ class _RecommendHeader extends StatelessWidget {
       child: SafeArea(
         bottom: false,
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(18, 10, 0, 12),
+              padding: EdgeInsets.fromLTRB(18, isCarMode ? 4 : 10, 0, 12),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Padding(
-                padding: const EdgeInsets.only(right: 18),
-                child: _TopTabs(
-                  auth: auth,
-                  index: sectionIndex,
-                  onChanged: onSectionChanged,
+              if (!isCarMode) ...[
+                Padding(
+                  padding: const EdgeInsets.only(right: 18),
+                  child: _TopTabs(
+                    auth: auth,
+                    index: sectionIndex,
+                    onChanged: onSectionChanged,
+                    onSettingsTap: onSettingsTap,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.only(right: 18),
-                child: _SmartSearch(api: api, auth: auth, player: player),
-              ),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.only(right: 18),
+                  child: _SmartSearch(api: api, auth: auth, player: player),
+                ),
+              ],
               if (updateVersion != null) ...[
                 const SizedBox(height: 10),
                 Padding(
@@ -444,12 +541,46 @@ class _RecommendHeader extends StatelessWidget {
               ],
               if (sectionIndex == 0) ...[
                 const SizedBox(height: 14),
-                _FeatureShelf(
-                  daily: daily,
-                  albums: albums,
-                  onDailyPlay: onDailyPlay,
-                  onAlbumTap: onAlbumTap,
-                ),
+                if (isUltraWide)
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        flex: 6,
+                        child: _FeatureShelf(
+                          daily: daily,
+                          albums: albums,
+                          onDailyPlay: onDailyPlay,
+                          onAlbumTap: onAlbumTap,
+                        ),
+                      ),
+                      Expanded(
+                        flex: 4,
+                        child: _CarQuickStatsPills(
+                          auth: auth,
+                          player: player,
+                          onSwitchToMyTab: () => onSectionChanged(-1),
+                          api: api,
+                          isSideBySide: true,
+                        ),
+                      ),
+                    ],
+                  )
+                else ...[
+                  _FeatureShelf(
+                    daily: daily,
+                    albums: albums,
+                    onDailyPlay: onDailyPlay,
+                    onAlbumTap: onAlbumTap,
+                  ),
+                  if (isCarMode)
+                    _CarQuickStatsPills(
+                      auth: auth,
+                      player: player,
+                      onSwitchToMyTab: () => onSectionChanged(-1),
+                      api: api,
+                    ),
+                ],
               ],
             ],
           ),
@@ -479,11 +610,13 @@ class _TopTabs extends StatelessWidget {
     required this.auth,
     required this.index,
     required this.onChanged,
+    required this.onSettingsTap,
   });
 
   final AuthController auth;
   final int index;
   final ValueChanged<int> onChanged;
+  final VoidCallback onSettingsTap;
 
   @override
   Widget build(BuildContext context) {
@@ -540,9 +673,9 @@ class _TopTabs extends StatelessWidget {
               ),
             ),
             IconButton(
-              tooltip: '菜单',
-              onPressed: () {},
-              icon: const Icon(Icons.menu_rounded),
+              tooltip: '设置',
+              onPressed: onSettingsTap,
+              icon: const Icon(Icons.settings_rounded),
             ),
           ],
         );
@@ -651,16 +784,23 @@ class _FeatureShelf extends StatelessWidget {
                   child: albums.isNotEmpty
                       ? _FeatureCard(
                           title: '新碟上架',
-                          subtitle: '${albums.first.singerName} · ${albums.first.albumName}',
+                          subtitle:
+                              '${albums.first.singerName} · ${albums.first.albumName}',
                           imageUrl: albums.first.coverUrl,
-                          gradient: const [Color(0xFF454A92), Color(0xFF78CAFF)],
+                          gradient: const [
+                            Color(0xFF454A92),
+                            Color(0xFF78CAFF),
+                          ],
                           onTap: onAlbumTap,
                         )
                       : _FeatureCard(
                           title: '新碟上架',
                           subtitle: '暂无新专辑',
                           imageUrl: null,
-                          gradient: const [Color(0xFF454A92), Color(0xFF78CAFF)],
+                          gradient: const [
+                            Color(0xFF454A92),
+                            Color(0xFF78CAFF),
+                          ],
                           onTap: () {},
                         ),
                 ),
@@ -796,7 +936,6 @@ class _SongSection extends StatefulWidget {
 }
 
 class _SongSectionState extends State<_SongSection> {
-  static const _perPage = 5;
   late final PageController _pageController;
   int _page = 0;
 
@@ -812,17 +951,11 @@ class _SongSectionState extends State<_SongSection> {
     super.dispose();
   }
 
-  int get _pageCount => (widget.songs.length / _perPage).ceil();
-
   @override
   Widget build(BuildContext context) {
     if (widget.songs.isEmpty) {
       return const SizedBox.shrink();
     }
-
-    final size = MediaQuery.sizeOf(context);
-    final isWide = size.width >= 720;
-    final rowCount = isWide ? (_perPage / 2).ceil() : _perPage;
 
     return AnimatedBuilder(
       animation: widget.auth,
@@ -845,104 +978,108 @@ class _SongSectionState extends State<_SongSection> {
                 ),
               ),
               const SizedBox(height: 8),
-              SizedBox(
-                height: rowCount * 76.0,
-                child: PageView.builder(
-                  controller: _pageController,
-                  itemCount: _pageCount,
-                  onPageChanged: (i) => setState(() => _page = i),
-                  itemBuilder: (context, pageIndex) {
-                    final start = pageIndex * _perPage;
-                    final end = (start + _perPage).clamp(0, widget.songs.length);
-                    final pageSongs = widget.songs.sublist(start, end);
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final maxWidth = constraints.maxWidth;
+                  final int crossAxisCount;
+                  final int itemsPerPage;
+                  if (maxWidth >= 1050) {
+                    crossAxisCount = 3;
+                    itemsPerPage = 6;
+                  } else if (maxWidth >= 650) {
+                    crossAxisCount = 2;
+                    itemsPerPage = 6;
+                  } else {
+                    crossAxisCount = 1;
+                    itemsPerPage = 5;
+                  }
 
-                    if (isWide) {
-                      return Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: Column(
+                  final rowCount = (itemsPerPage / crossAxisCount).ceil();
+                  final pageCount = (widget.songs.length / itemsPerPage).ceil();
+
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        height: rowCount * 76.0,
+                        child: PageView.builder(
+                          controller: _pageController,
+                          itemCount: pageCount,
+                          onPageChanged: (i) => setState(() => _page = i),
+                          itemBuilder: (context, pageIndex) {
+                            final start = pageIndex * itemsPerPage;
+                            final end = (start + itemsPerPage).clamp(
+                              0,
+                              widget.songs.length,
+                            );
+                            final pageSongs = widget.songs.sublist(start, end);
+
+                            return Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                for (var i = 0; i < pageSongs.length; i += 2)
-                                  _HomeSongRow(
-                                    song: pageSongs[i],
-                                    queue: widget.songs,
-                                    onPlay: widget.onPlay,
-                                    isLiked: widget.isLiked(pageSongs[i]),
-                                    onLikeTap: () => widget.onLikeTap(pageSongs[i]),
-                                    auth: widget.auth,
-                                    player: widget.player,
-                                    onViewArtist: () => widget.onViewArtist(pageSongs[i]),
-                                  ),
-                              ],
-                            ),
-                          ),
-                          if (pageSongs.length > 1) ...[
-                            const SizedBox(width: 16),
-                            Expanded(
-                              child: Column(
-                                children: [
-                                  for (var i = 1; i < pageSongs.length; i += 2)
-                                    _HomeSongRow(
-                                      song: pageSongs[i],
-                                      queue: widget.songs,
-                                      onPlay: widget.onPlay,
-                                      isLiked: widget.isLiked(pageSongs[i]),
-                                      onLikeTap: () => widget.onLikeTap(pageSongs[i]),
-                                      auth: widget.auth,
-                                      player: widget.player,
-                                      onViewArtist: () => widget.onViewArtist(pageSongs[i]),
+                                for (
+                                  int col = 0;
+                                  col < crossAxisCount;
+                                  col++
+                                ) ...[
+                                  if (col > 0) const SizedBox(width: 16),
+                                  Expanded(
+                                    child: Column(
+                                      children: [
+                                        for (
+                                          int i = col;
+                                          i < pageSongs.length;
+                                          i += crossAxisCount
+                                        )
+                                          _HomeSongRow(
+                                            song: pageSongs[i],
+                                            queue: widget.songs,
+                                            onPlay: widget.onPlay,
+                                            isLiked: widget.isLiked(
+                                              pageSongs[i],
+                                            ),
+                                            onLikeTap: () =>
+                                                widget.onLikeTap(pageSongs[i]),
+                                            auth: widget.auth,
+                                            player: widget.player,
+                                            onViewArtist: () => widget
+                                                .onViewArtist(pageSongs[i]),
+                                          ),
+                                      ],
                                     ),
+                                  ),
                                 ],
-                              ),
-                            ),
-                          ],
-                        ],
-                      );
-                    }
-
-                    return Column(
-                      children: [
-                        for (final song in pageSongs)
-                          _HomeSongRow(
-                            song: song,
-                            queue: widget.songs,
-                            onPlay: widget.onPlay,
-                            isLiked: widget.isLiked(song),
-                            onLikeTap: () => widget.onLikeTap(song),
-                            auth: widget.auth,
-                            player: widget.player,
-                            onViewArtist: () => widget.onViewArtist(song),
-                          ),
-                      ],
-                    );
-                  },
-                ),
-              ),
-              if (_pageCount > 1) ...[
-                const SizedBox(height: 10),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: List.generate(_pageCount, (i) {
-                    final active = i == _page;
-                    return AnimatedContainer(
-                      duration: const Duration(milliseconds: 200),
-                      width: active ? 16 : 6,
-                      height: 6,
-                      margin: const EdgeInsets.symmetric(horizontal: 3),
-                      decoration: BoxDecoration(
-                        color: active
-                            ? Theme.of(context).colorScheme.primary
-                            : Theme.of(context)
-                                .colorScheme
-                                .outline
-                                .withValues(alpha: .3),
-                        borderRadius: BorderRadius.circular(99),
+                              ],
+                            );
+                          },
+                        ),
                       ),
-                    );
-                  }),
-                ),
-              ],
+                      if (pageCount > 1) ...[
+                        const SizedBox(height: 10),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: List.generate(pageCount, (i) {
+                            final active = i == _page;
+                            return AnimatedContainer(
+                              duration: const Duration(milliseconds: 200),
+                              width: active ? 16 : 6,
+                              height: 6,
+                              margin: const EdgeInsets.symmetric(horizontal: 3),
+                              decoration: BoxDecoration(
+                                color: active
+                                    ? Theme.of(context).colorScheme.primary
+                                    : Theme.of(context).colorScheme.outline
+                                          .withValues(alpha: .3),
+                                borderRadius: BorderRadius.circular(99),
+                              ),
+                            );
+                          }),
+                        ),
+                      ],
+                    ],
+                  );
+                },
+              ),
             ],
           ),
         );
@@ -976,147 +1113,155 @@ class _HomeSongRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return AnimatedBuilder(
-      animation: player,
-      builder: (context, _) {
-        final active =
-            song.hash.isNotEmpty && player.currentSong?.hash == song.hash;
-        final activeColor = colorScheme.primary;
-        return GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () => onPlay(song, queue),
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 180),
-            padding: const EdgeInsets.symmetric(vertical: 9, horizontal: 8),
-            decoration: BoxDecoration(
-              color: Colors.transparent,
-              borderRadius: BorderRadius.circular(14),
-            ),
-            child: Row(
-              children: [
-                Stack(
-                  children: [
-                    Artwork(url: song.coverUrl, size: 58, borderRadius: 8),
-                    if (active)
-                      Positioned(
-                        right: 5,
-                        bottom: 5,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.surface.withValues(alpha: .88),
-                            borderRadius: BorderRadius.circular(7),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.all(3),
-                            child: NowPlayingBadge(
-                              active: active,
-                              playing: player.isPlaying,
-                              color: activeColor,
-                              size: 14,
+    // 主页歌曲行响应 player 重建（播放进度/状态），高频更新会触发
+    // Windows AXTree 竞态崩溃，排除语义树以规避 Flutter Windows 引擎 bug
+    return ExcludeSemantics(
+      child: AnimatedBuilder(
+        animation: player,
+        builder: (context, _) {
+          final active =
+              song.hash.isNotEmpty && player.currentSong?.hash == song.hash;
+          final activeColor = colorScheme.primary;
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => onPlay(song, queue),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 180),
+              padding: const EdgeInsets.symmetric(vertical: 9, horizontal: 8),
+              decoration: BoxDecoration(
+                color: Colors.transparent,
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Row(
+                children: [
+                  Stack(
+                    children: [
+                      Artwork(url: song.coverUrl, size: 58, borderRadius: 8),
+                      if (active)
+                        Positioned(
+                          right: 5,
+                          bottom: 5,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.surface.withValues(alpha: .88),
+                              borderRadius: BorderRadius.circular(7),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(3),
+                              child: NowPlayingBadge(
+                                active: active,
+                                playing: player.isPlaying,
+                                color: activeColor,
+                                size: 14,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                  ],
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        song.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          color: active ? activeColor : null,
-                          fontWeight: FontWeight.w700,
-                          fontSize: 16,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        song.artist,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: active
-                              ? activeColor.withValues(alpha: .72)
-                              : colorScheme.onSurfaceVariant,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
                     ],
                   ),
-                ),
-                const SizedBox(width: 10),
-                IconButton(
-                  onPressed: onLikeTap,
-                  icon: Icon(
-                    isLiked
-                        ? Icons.favorite_rounded
-                        : Icons.favorite_border_rounded,
-                    color: isLiked ? Colors.redAccent : colorScheme.outline,
-                    size: 27,
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          song.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(
+                                color: active ? activeColor : null,
+                                fontWeight: FontWeight.w700,
+                                fontSize: 16,
+                              ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          song.artist,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: active
+                                    ? activeColor.withValues(alpha: .72)
+                                    : colorScheme.onSurfaceVariant,
+                                fontWeight: FontWeight.w500,
+                              ),
+                        ),
+                      ],
+                    ),
                   ),
-                  visualDensity: VisualDensity.compact,
-                ),
-                IconButton(
-                  tooltip: '更多',
-                  onPressed: () {
-                    showSongActionSheet(
-                      context: context,
-                      song: song,
-                      actions: [
-                        SongSheetAction(
-                          icon: Icons.queue_music_rounded,
-                          title: '下一首播放',
-                          onTap: () => addSongToQueueWithFeedback(
-                            context: context,
-                            player: player,
-                            song: song,
-                          ),
-                        ),
-                        SongSheetAction(
-                          icon: Icons.playlist_add_rounded,
-                          title: '添加到歌单',
-                          onTap: () => showAddToPlaylistSheet(
-                            context: context,
-                            auth: auth,
-                            song: song,
-                          ),
-                        ),
-                        SongSheetAction(
-                          icon: Icons.person_rounded,
-                          title: '查看歌手',
-                          onTap: onViewArtist,
-                        ),
-                        if (player.downloadController != null)
+                  const SizedBox(width: 10),
+                  IconButton(
+                    onPressed: onLikeTap,
+                    icon: Icon(
+                      isLiked
+                          ? Icons.favorite_rounded
+                          : Icons.favorite_border_rounded,
+                      color: isLiked ? Colors.redAccent : colorScheme.outline,
+                      size: 27,
+                    ),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                  IconButton(
+                    tooltip: '更多',
+                    onPressed: () {
+                      showSongActionSheet(
+                        context: context,
+                        song: song,
+                        actions: [
                           SongSheetAction(
-                            icon: player.downloadController!.isDownloaded(song)
-                                ? Icons.download_done_rounded
-                                : Icons.download_rounded,
-                            title: player.downloadController!.isDownloaded(song)
-                                ? '已下载'
-                                : '下载',
-                            onTap: () => player.downloadController!.download(
-                              song,
-                              player.audioQuality,
+                            icon: Icons.queue_music_rounded,
+                            title: '下一首播放',
+                            onTap: () => addSongToQueueWithFeedback(
+                              context: context,
+                              player: player,
+                              song: song,
                             ),
                           ),
-                      ],
-                    );
-                  },
-                  icon: const Icon(Icons.more_horiz_rounded),
-                  visualDensity: VisualDensity.compact,
-                ),
-              ],
+                          SongSheetAction(
+                            icon: Icons.playlist_add_rounded,
+                            title: '添加到歌单',
+                            onTap: () => showAddToPlaylistSheet(
+                              context: context,
+                              auth: auth,
+                              song: song,
+                            ),
+                          ),
+                          SongSheetAction(
+                            icon: Icons.person_rounded,
+                            title: '查看歌手',
+                            onTap: onViewArtist,
+                          ),
+                          if (player.downloadController != null)
+                            SongSheetAction(
+                              icon:
+                                  player.downloadController!.isDownloaded(song)
+                                  ? Icons.download_done_rounded
+                                  : Icons.download_rounded,
+                              title:
+                                  player.downloadController!.isDownloaded(song)
+                                  ? '已下载'
+                                  : '下载',
+                              onTap: () => player.downloadController!.download(
+                                song,
+                                player.audioQuality,
+                              ),
+                            ),
+                        ],
+                      );
+                    },
+                    icon: const Icon(Icons.more_horiz_rounded),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ],
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }
@@ -1131,6 +1276,49 @@ class _PlaylistRail extends StatelessWidget {
   Widget build(BuildContext context) {
     if (playlists.isEmpty) {
       return const SizedBox.shrink();
+    }
+
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width > size.height;
+    // 推荐歌单网格布局是车机专属，普通横屏用横向列表。
+    final isCarMode = isLandscape && ThemeController.instance.carModeEnabled;
+
+    if (isCarMode) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 18),
+              child: _SectionHeader(
+                title: '推荐歌单',
+                action: const SizedBox.shrink(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(horizontal: 18),
+              itemCount: playlists.length,
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 160,
+                mainAxisSpacing: 16,
+                crossAxisSpacing: 14,
+                childAspectRatio: 0.60,
+              ),
+              itemBuilder: (context, index) {
+                final playlist = playlists[index];
+                return _PlaylistCard(
+                  playlist: playlist,
+                  onTap: () => onTap(playlist),
+                );
+              },
+            ),
+          ],
+        ),
+      );
     }
 
     return Padding(
@@ -1157,6 +1345,7 @@ class _PlaylistRail extends StatelessWidget {
                 return _PlaylistCard(
                   playlist: playlist,
                   onTap: () => onTap(playlist),
+                  width: 128,
                 );
               },
             ),
@@ -1194,22 +1383,28 @@ class _SectionHeader extends StatelessWidget {
 }
 
 class _PlaylistCard extends StatelessWidget {
-  const _PlaylistCard({required this.playlist, required this.onTap});
+  const _PlaylistCard({
+    required this.playlist,
+    required this.onTap,
+    this.width,
+  });
 
   final PlaylistSummary playlist;
   final VoidCallback onTap;
+  final double? width;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 128,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: onTap,
-        child: Column(
+    Widget content = LayoutBuilder(
+      builder: (context, constraints) {
+        final cardWidth = width ?? constraints.maxWidth;
+        final size = cardWidth.isInfinite ? 128.0 : cardWidth;
+
+        return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Artwork(url: playlist.coverUrl, size: 128, borderRadius: 10),
+            Artwork(url: playlist.coverUrl, size: size, borderRadius: 10),
             const SizedBox(height: 9),
             SizedBox(
               height: 42,
@@ -1232,8 +1427,25 @@ class _PlaylistCard extends StatelessWidget {
               ),
             ),
           ],
+        );
+      },
+    );
+
+    if (width != null) {
+      return SizedBox(
+        width: width,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: content,
         ),
-      ),
+      );
+    }
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: content,
     );
   }
 }
@@ -1296,7 +1508,9 @@ class _RadioSectionState extends State<_RadioSection> {
   Future<void> _refresh() async {
     final future = _load();
     _cachedFuture = future;
-    setState(() { _future = future; });
+    setState(() {
+      _future = future;
+    });
     await future;
   }
 
@@ -1331,6 +1545,11 @@ class _RadioSectionState extends State<_RadioSection> {
 
   @override
   Widget build(BuildContext context) {
+    final screenSize = MediaQuery.sizeOf(context);
+    final isLandscape = screenSize.width > screenSize.height;
+    // 电台双卡+网格布局是车机专属，普通横屏用原布局。
+    final isCarMode = isLandscape && ThemeController.instance.carModeEnabled;
+
     return FutureBuilder<_RadioData>(
       future: _future,
       builder: (context, snapshot) {
@@ -1346,6 +1565,103 @@ class _RadioSectionState extends State<_RadioSection> {
           );
         }
         final radio = data ?? _RadioData.empty;
+
+        if (isCarMode) {
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(18, 0, 18, 12),
+                  child: _SectionHeader(
+                    title: '推荐电台',
+                    action: IconButton.filledTonal(
+                      tooltip: '刷新',
+                      onPressed: _refresh,
+                      icon: const Icon(Icons.refresh_rounded),
+                      style: IconButton.styleFrom(
+                        fixedSize: const Size.square(42),
+                        shape: const CircleBorder(),
+                      ),
+                    ),
+                  ),
+                ),
+                if (radio.recommended.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 18),
+                    child: SizedBox(
+                      height: 190,
+                      child: radio.recommended.length >= 2
+                          // 有两个及以上推荐时，并排展示两张大卡
+                          ? Row(
+                              children: [
+                                Expanded(
+                                  child: _RadioHeroCard(
+                                    station: radio.recommended[0],
+                                    loading:
+                                        _loadingStationId ==
+                                        radio.recommended[0].id,
+                                    onTap: () =>
+                                        _playStation(radio.recommended[0]),
+                                  ),
+                                ),
+                                const SizedBox(width: 14),
+                                Expanded(
+                                  child: _RadioHeroCard(
+                                    station: radio.recommended[1],
+                                    loading:
+                                        _loadingStationId ==
+                                        radio.recommended[1].id,
+                                    onTap: () =>
+                                        _playStation(radio.recommended[1]),
+                                  ),
+                                ),
+                              ],
+                            )
+                          : _RadioHeroCard(
+                              station: radio.recommended.first,
+                              loading:
+                                  _loadingStationId ==
+                                  radio.recommended.first.id,
+                              onTap: () =>
+                                  _playStation(radio.recommended.first),
+                            ),
+                    ),
+                  ),
+                if (radio.recommended.length > 2) ...[
+                  const SizedBox(height: 14),
+                  _RadioStationGrid(
+                    stations: radio.recommended.skip(2).toList(),
+                    loadingStationId: _loadingStationId,
+                    onTap: _playStation,
+                  ),
+                ],
+                for (final group in radio.groups) ...[
+                  const SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 18),
+                    child: _SectionHeader(
+                      title: group.name,
+                      action: Icon(
+                        Icons.radio_rounded,
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  _RadioStationGrid(
+                    stations: group.stations,
+                    loadingStationId: _loadingStationId,
+                    onTap: _playStation,
+                  ),
+                ],
+                if (radio.recommended.isEmpty && radio.groups.isEmpty)
+                  const _RadioEmpty(),
+              ],
+            ),
+          );
+        }
 
         return Padding(
           padding: const EdgeInsets.fromLTRB(18, 0, 18, 24),
@@ -1525,6 +1841,45 @@ class _RadioStationRail extends StatelessWidget {
           );
         },
       ),
+    );
+  }
+}
+
+class _RadioStationGrid extends StatelessWidget {
+  const _RadioStationGrid({
+    required this.stations,
+    required this.loadingStationId,
+    required this.onTap,
+  });
+
+  final List<FmStation> stations;
+  final String? loadingStationId;
+  final ValueChanged<FmStation> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (stations.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(horizontal: 18),
+      itemCount: stations.length,
+      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+        maxCrossAxisExtent: 160,
+        mainAxisSpacing: 16,
+        crossAxisSpacing: 14,
+        childAspectRatio: 0.72,
+      ),
+      itemBuilder: (context, index) {
+        final station = stations[index];
+        return _RadioStationCard(
+          station: station,
+          loading: loadingStationId == station.id,
+          onTap: () => onTap(station),
+        );
+      },
     );
   }
 }
@@ -1915,4 +2270,178 @@ String _playCount(int? value) {
     return '${(value / 10000).toStringAsFixed(1)} 万次播放';
   }
   return '$value 次播放';
+}
+
+class _CarQuickStatsPills extends StatefulWidget {
+  const _CarQuickStatsPills({
+    required this.auth,
+    required this.player,
+    required this.onSwitchToMyTab,
+    required this.api,
+    this.isSideBySide = false,
+  });
+
+  final AuthController auth;
+  final PlayerController player;
+  final VoidCallback onSwitchToMyTab;
+  final MusicApi api;
+  final bool isSideBySide;
+
+  @override
+  State<_CarQuickStatsPills> createState() => _CarQuickStatsPillsState();
+}
+
+class _CarQuickStatsPillsState extends State<_CarQuickStatsPills> {
+  int _historyCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHistoryCount();
+  }
+
+  Future<void> _loadHistoryCount() async {
+    try {
+      final count = await widget.player.getPlaybackHistoryCount();
+      if (mounted) {
+        setState(() {
+          _historyCount = count;
+        });
+      }
+    } catch (_) {}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(top: widget.isSideBySide ? 0 : 20, right: 18),
+      child: Row(
+        children: [
+          Expanded(
+            child: _PillCard(
+              title: '已播歌曲',
+              value: '$_historyCount',
+              onTap: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => PlaybackHistoryPage(
+                    api: widget.api,
+                    auth: widget.auth,
+                    player: widget.player,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: _PillCard(
+              title: '收藏歌曲',
+              value: '${widget.auth.likedCount}',
+              onTap: () {
+                if (widget.auth.likedPlaylist != null) {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => PlaylistDetailPage(
+                        api: widget.api,
+                        auth: widget.auth,
+                        player: widget.player,
+                        playlist: widget.auth.likedPlaylist!,
+                      ),
+                    ),
+                  );
+                } else {
+                  Toast.info('暂无收藏歌单');
+                }
+              },
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: _PillCard(
+              title: '自建歌单',
+              value: '${widget.auth.createdPlaylists.length}',
+              onTap: widget.onSwitchToMyTab,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PillCard extends StatelessWidget {
+  const _PillCard({
+    required this.title,
+    required this.value,
+    required this.onTap,
+  });
+
+  final String title;
+  final String value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Material(
+      color: isDark
+          ? colorScheme.surfaceContainer
+          : Colors.white.withValues(alpha: 0.9),
+      borderRadius: BorderRadius.circular(28),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: const BoxDecoration(
+                  color: Color(0xFF1DB954), // Spotify Green
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.play_arrow_rounded,
+                  color: Colors.white,
+                  size: 22,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.onSurfaceVariant,
+                        fontSize: 13,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      value,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.w900,
+                        color: colorScheme.onSurface,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/ui/pages/library_page.dart
+++ b/lib/ui/pages/library_page.dart
@@ -67,6 +67,11 @@ class _LibraryPageState extends State<LibraryPage>
     );
   }
 
+  bool _isLandscape(BuildContext ctx) {
+    final size = MediaQuery.sizeOf(ctx);
+    return size.width > size.height;
+  }
+
   void _openSettings() {
     Navigator.of(context).push(
       MaterialPageRoute(
@@ -167,11 +172,13 @@ class _LibraryPageState extends State<LibraryPage>
                             onPressed: _showCreatePlaylistDialog,
                             icon: const Icon(Icons.add_rounded),
                           ),
-                          IconButton(
-                            tooltip: '设置',
-                            onPressed: _openSettings,
-                            icon: const Icon(Icons.settings_rounded),
-                          ),
+                          // 车机模式顶栏已有设置按钮，隐藏此处重复按钮
+                          if (!(_isLandscape(context) && widget.theme.carModeEnabled))
+                            IconButton(
+                              tooltip: '设置',
+                              onPressed: _openSettings,
+                              icon: const Icon(Icons.settings_rounded),
+                            ),
                         ],
                       ),
                     ),

--- a/lib/ui/pages/player_page.dart
+++ b/lib/ui/pages/player_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
-import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -995,6 +994,8 @@ class _LandscapeRightPanel extends StatelessWidget {
             Expanded(
               child: _LandscapeLyricPanel(
                 player: player,
+                songHash: song?.hash ?? '',
+                lyrics: player.lyrics,
                 compact: compact || veryTight,
               ),
             ),
@@ -1016,9 +1017,16 @@ class _LandscapeRightPanel extends StatelessWidget {
 }
 
 class _LandscapeLyricPanel extends StatefulWidget {
-  const _LandscapeLyricPanel({required this.player, required this.compact});
+  const _LandscapeLyricPanel({
+    required this.player,
+    required this.songHash,
+    required this.lyrics,
+    required this.compact,
+  });
 
   final PlayerController player;
+  final String songHash;
+  final List<LyricLine> lyrics;
   final bool compact;
 
   @override
@@ -1028,10 +1036,6 @@ class _LandscapeLyricPanel extends StatefulWidget {
 class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   late final LyricController _lyricController;
   late final Ticker _ticker;
-  // flutter_lyric 内部通过 isSelectingNotifier 标记用户是否在拖动歌词。
-  // LyricView 是 CustomPaint 自绘，不产生 ScrollNotification，外层
-  // NotificationListener 无效；改为监听 isSelectingNotifier 控制 ticker，
-  // 用户拖动时停止 setProgress，避免与 flutter_lyric 内部 fling/恢复竞态。
   bool _isUserSelecting = false;
 
   @override
@@ -1050,10 +1054,8 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   @override
   void didUpdateWidget(covariant _LandscapeLyricPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
-    // 只有歌词内容真正变化时才重新加载。
-    // 如果无条件地在每次 didUpdateWidget（每帧）调用 _syncLyrics()，
-    // loadLyricModel 会完全重置 controller 内部滚动状态，导致用户滑动时视图每帧跳回当前播放行。
-    if (!listEquals(oldWidget.player.lyrics, widget.player.lyrics)) {
+    if (oldWidget.songHash != widget.songHash ||
+        oldWidget.lyrics != widget.lyrics) {
       _syncLyrics();
     }
     _syncTicker();
@@ -1073,7 +1075,7 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   }
 
   void _syncLyrics() {
-    final lyrics = widget.player.lyrics;
+    final lyrics = widget.lyrics;
     if (lyrics.isNotEmpty) {
       final model = convertToFlutterLyricModel(lyrics);
       _lyricController.loadLyricModel(model);
@@ -1083,7 +1085,7 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   void _syncTicker() {
     final shouldTick =
         widget.player.isPlaying &&
-        widget.player.lyrics.isNotEmpty &&
+        widget.lyrics.isNotEmpty &&
         !widget.player.isScrubbing &&
         !_isUserSelecting;
     if (shouldTick && !_ticker.isActive) {
@@ -1103,7 +1105,7 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   @override
   Widget build(BuildContext context) {
     final player = widget.player;
-    final lyrics = widget.player.lyrics;
+    final lyrics = widget.lyrics;
     if (lyrics.isEmpty) {
       return Align(
         alignment: Alignment.centerLeft,

--- a/lib/ui/pages/player_page.dart
+++ b/lib/ui/pages/player_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -13,7 +14,6 @@ import '../../controllers/player_controller.dart';
 import '../../controllers/theme_controller.dart';
 import '../../models/music_models.dart';
 import '../../services/lyric_converter.dart';
-import '../adaptive_layout.dart';
 import '../widgets/audio_effects_sheet.dart';
 import '../widgets/audio_quality_sheet.dart';
 import '../widgets/artwork.dart';
@@ -46,29 +46,15 @@ class _PlayerPageState extends State<PlayerPage> {
   void initState() {
     super.initState();
     unawaited(_setKeepScreenOn(true));
-    SystemChrome.setPreferredOrientations(const [
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.landscapeLeft,
-      DeviceOrientation.landscapeRight,
-    ]);
+    // 不在此处调用 setPreferredOrientations：方向策略由 ThemeController 全局管理。
+    // 如果这里解锁方向，即使用户在设置里没开横屏模式，旋转手机时播放页也会
+    // 跟着旋转，影响竖屏体验。
   }
 
   @override
   void dispose() {
     unawaited(_setKeepScreenOn(false));
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
-    
-    final isTablet = AdaptiveLayout.isTabletByPlatform();
-    if (isTablet || ThemeController.instance.landscapeEnabled) {
-      SystemChrome.setPreferredOrientations(const [
-        DeviceOrientation.portraitUp,
-        DeviceOrientation.portraitDown,
-        DeviceOrientation.landscapeLeft,
-        DeviceOrientation.landscapeRight,
-      ]);
-    } else {
-      SystemChrome.setPreferredOrientations(const [DeviceOrientation.portraitUp]);
-    }
     super.dispose();
   }
 
@@ -201,8 +187,16 @@ class _PlayerBodyState extends State<_PlayerBody> {
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
+    if (size.height < 150 || size.width < 150) {
+      return const Scaffold(
+        backgroundColor: Colors.black,
+        body: SizedBox.shrink(),
+      );
+    }
     final landscape = size.width > size.height;
     _syncSystemUi(landscape);
+    // 横屏分栏布局是车机专属，普通横屏仍用竖屏的翻页布局。
+    final isCarLayout = landscape && ThemeController.instance.carModeEnabled;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: const SystemUiOverlayStyle(
@@ -215,11 +209,11 @@ class _PlayerBodyState extends State<_PlayerBody> {
           children: [
             _ArtworkBackground(song: widget.song),
             SafeArea(
-              top: !landscape,
-              bottom: !landscape,
+              // 横屏时同样需要处理顶部状态栏和底部系统导航栏（如车机空调控制栏）的遮挡。
+              // 竖屏已由外层 Scaffold 处理，这里对所有方向统一保留 SafeArea。
               child: Column(
                 children: [
-                  if (!landscape)
+                  if (!isCarLayout)
                     _TopBar(
                       player: widget.player,
                       auth: widget.auth,
@@ -228,14 +222,16 @@ class _PlayerBodyState extends State<_PlayerBody> {
                       onArtistTap: _openArtist,
                     ),
                   Expanded(
-                    child: landscape
-                        ? _LandscapePlayerContent(
-                            player: widget.player,
-                            auth: widget.auth,
-                            song: widget.song,
-                            onClose: widget.onClose,
-                            onQueue: widget.onQueue,
-                            onArtistTap: _openArtist,
+                    child: isCarLayout
+                        ? ExcludeSemantics(
+                            child: _LandscapePlayerContent(
+                              player: widget.player,
+                              auth: widget.auth,
+                              song: widget.song,
+                              onClose: widget.onClose,
+                              onQueue: widget.onQueue,
+                              onArtistTap: _openArtist,
+                            ),
                           )
                         : NotificationListener<ScrollNotification>(
                             onNotification: _handlePageScrollNotification,
@@ -268,7 +264,7 @@ class _PlayerBodyState extends State<_PlayerBody> {
                             ),
                           ),
                   ),
-                  if (!landscape) _PageDots(page: _page),
+                  if (!isCarLayout) _PageDots(page: _page),
                 ],
               ),
             ),
@@ -287,9 +283,7 @@ class _PlayerBodyState extends State<_PlayerBody> {
       if (!mounted) {
         return;
       }
-      SystemChrome.setEnabledSystemUIMode(
-        landscape ? SystemUiMode.immersiveSticky : SystemUiMode.edgeToEdge,
-      );
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     });
   }
 
@@ -462,45 +456,48 @@ class _ArtworkBackgroundState extends State<_ArtworkBackground>
     final maxDim = math.max(size.width, size.height);
     final squareSize = maxDim * 1.5;
 
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        if (coverUrl != null)
-          OverflowBox(
-            maxWidth: squareSize,
-            maxHeight: squareSize,
-            minWidth: squareSize,
-            minHeight: squareSize,
-            child: ImageFiltered(
-              imageFilter: ImageFilter.blur(sigmaX: 34, sigmaY: 34),
-              child: RotationTransition(
-                turns: _rotationController,
-                child: Image.network(
-                  coverUrl,
-                  fit: BoxFit.cover,
-                  errorBuilder: (context, error, stackTrace) =>
-                      const _FallbackBackground(),
+    // 旋转动画背景是纯装饰性的，排除语义树防止 Windows AXTree 竞态崩溃
+    return ExcludeSemantics(
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (coverUrl != null)
+            OverflowBox(
+              maxWidth: squareSize,
+              maxHeight: squareSize,
+              minWidth: squareSize,
+              minHeight: squareSize,
+              child: ImageFiltered(
+                imageFilter: ImageFilter.blur(sigmaX: 34, sigmaY: 34),
+                child: RotationTransition(
+                  turns: _rotationController,
+                  child: Image.network(
+                    coverUrl,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) =>
+                        const _FallbackBackground(),
+                  ),
                 ),
               ),
-            ),
-          )
-        else
-          const _FallbackBackground(),
-        DecoratedBox(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: [
-                Colors.black.withValues(alpha: .32),
-                Colors.black.withValues(alpha: .56),
-                Colors.black.withValues(alpha: .82),
-              ],
+            )
+          else
+            const _FallbackBackground(),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.black.withValues(alpha: .32),
+                  Colors.black.withValues(alpha: .56),
+                  Colors.black.withValues(alpha: .82),
+                ],
+              ),
             ),
           ),
-        ),
-        ColoredBox(color: Colors.black.withValues(alpha: .12)),
-      ],
+          ColoredBox(color: Colors.black.withValues(alpha: .12)),
+        ],
+      ),
     );
   }
 }
@@ -549,7 +546,7 @@ class _LandscapePlayerContent extends StatelessWidget {
             compact ? 14 : 24,
             compact ? 4 : 10,
             compact ? 16 : 30,
-            compact ? 8 : 14,
+            compact ? 24 : 36,
           ),
           child: Column(
             children: [
@@ -847,83 +844,97 @@ class _LandscapeArtworkShowcaseState extends State<_LandscapeArtworkShowcase>
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final available = math.min(constraints.maxWidth, constraints.maxHeight);
-        final discSize = (available * (widget.compact ? .84 : .9))
-            .clamp(150.0, 330.0)
-            .toDouble();
-        final coverSize = discSize * (widget.compact ? .58 : .70);
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onHorizontalDragEnd: (details) {
+        final velocity = details.primaryVelocity ?? 0.0;
+        if (velocity < -200) {
+          widget.player.next();
+        } else if (velocity > 200) {
+          widget.player.previous();
+        }
+      },
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final available = math.min(constraints.maxWidth, constraints.maxHeight);
+          final discSize = (available * (widget.compact ? .84 : .9))
+              .clamp(150.0, 330.0)
+              .toDouble();
+          final coverSize = discSize * (widget.compact ? .58 : .70);
 
-        return Center(
-          child: SizedBox.square(
-            dimension: discSize,
-            child: AnimatedBuilder(
-              animation: _rotationController,
-              builder: (context, child) {
-                return Transform.rotate(
-                  angle: _rotationController.value * math.pi * 2,
-                  child: child,
-                );
-              },
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  DecoratedBox(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      gradient: RadialGradient(
-                        colors: [
-                          Colors.white.withValues(alpha: .88),
-                          Colors.white.withValues(alpha: .58),
-                          Colors.white.withValues(alpha: .22),
-                        ],
-                        stops: const [0, .62, 1],
-                      ),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: .26),
-                          blurRadius: 30,
-                          offset: const Offset(0, 18),
-                        ),
-                      ],
-                    ),
-                    child: const SizedBox.expand(),
-                  ),
-                  for (final ratio in const [.36, .52, .68, .82])
-                    SizedBox.square(
-                      dimension: discSize * ratio,
-                      child: DecoratedBox(
+          return Center(
+            // 旋转唱片是纯装饰动画，排除语义树防止 Windows AXTree 竞态崩溃
+            child: ExcludeSemantics(
+              child: SizedBox.square(
+                dimension: discSize,
+                child: AnimatedBuilder(
+                  animation: _rotationController,
+                  builder: (context, child) {
+                    return Transform.rotate(
+                      angle: _rotationController.value * math.pi * 2,
+                      child: child,
+                    );
+                  },
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      DecoratedBox(
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
-                          border: Border.all(
-                            color: Colors.white.withValues(alpha: .16),
+                          gradient: RadialGradient(
+                            colors: [
+                              Colors.white.withValues(alpha: .88),
+                              Colors.white.withValues(alpha: .58),
+                              Colors.white.withValues(alpha: .22),
+                            ],
+                            stops: const [0, .62, 1],
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: .26),
+                              blurRadius: 30,
+                              offset: const Offset(0, 18),
+                            ),
+                          ],
+                        ),
+                        child: const SizedBox.expand(),
+                      ),
+                      for (final ratio in const [.36, .52, .68, .82])
+                        SizedBox.square(
+                          dimension: discSize * ratio,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              border: Border.all(
+                                color: Colors.white.withValues(alpha: .16),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ClipOval(
+                        child: Artwork(
+                          url: widget.song.coverUrl,
+                          size: coverSize,
+                          borderRadius: coverSize,
+                        ),
+                      ),
+                      SizedBox.square(
+                        dimension: discSize * .08,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.white.withValues(alpha: .82),
                           ),
                         ),
                       ),
-                    ),
-                  ClipOval(
-                    child: Artwork(
-                      url: widget.song.coverUrl,
-                      size: coverSize,
-                      borderRadius: coverSize,
-                    ),
+                    ],
                   ),
-                  SizedBox.square(
-                    dimension: discSize * .08,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: Colors.white.withValues(alpha: .82),
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }
@@ -941,12 +952,46 @@ class _LandscapeRightPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final song = player.currentSong;
     return LayoutBuilder(
       builder: (context, constraints) {
         final veryTight = constraints.maxHeight < 250;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            if (song != null)
+              Padding(
+                padding: EdgeInsets.only(
+                  bottom: veryTight ? 6.0 : 12.0,
+                  top: veryTight ? 2.0 : 6.0,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      song.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            color: Colors.white.withValues(alpha: .92),
+                            fontSize: compact ? 18 : 22,
+                            fontWeight: FontWeight.w900,
+                          ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      song.artist,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.white.withValues(alpha: .6),
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                  ],
+                ),
+              ),
             Expanded(
               child: _LandscapeLyricPanel(
                 player: player,
@@ -983,11 +1028,20 @@ class _LandscapeLyricPanel extends StatefulWidget {
 class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   late final LyricController _lyricController;
   late final Ticker _ticker;
+  // flutter_lyric 内部通过 isSelectingNotifier 标记用户是否在拖动歌词。
+  // LyricView 是 CustomPaint 自绘，不产生 ScrollNotification，外层
+  // NotificationListener 无效；改为监听 isSelectingNotifier 控制 ticker，
+  // 用户拖动时停止 setProgress，避免与 flutter_lyric 内部 fling/恢复竞态。
+  bool _isUserSelecting = false;
 
   @override
   void initState() {
     super.initState();
     _lyricController = LyricController();
+    _lyricController.setOnTapLineCallback((position) {
+      widget.player.seek(position);
+    });
+    _lyricController.isSelectingNotifier.addListener(_onSelectingChanged);
     _syncLyrics();
     _ticker = Ticker(_onTick);
     _syncTicker();
@@ -996,15 +1050,26 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
   @override
   void didUpdateWidget(covariant _LandscapeLyricPanel oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _syncLyrics();
+    // 只有歌词内容真正变化时才重新加载。
+    // 如果无条件地在每次 didUpdateWidget（每帧）调用 _syncLyrics()，
+    // loadLyricModel 会完全重置 controller 内部滚动状态，导致用户滑动时视图每帧跳回当前播放行。
+    if (!listEquals(oldWidget.player.lyrics, widget.player.lyrics)) {
+      _syncLyrics();
+    }
     _syncTicker();
   }
 
   @override
   void dispose() {
+    _lyricController.isSelectingNotifier.removeListener(_onSelectingChanged);
     _ticker.dispose();
     _lyricController.dispose();
     super.dispose();
+  }
+
+  void _onSelectingChanged() {
+    _isUserSelecting = _lyricController.isSelectingNotifier.value;
+    _syncTicker();
   }
 
   void _syncLyrics() {
@@ -1019,7 +1084,8 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
     final shouldTick =
         widget.player.isPlaying &&
         widget.player.lyrics.isNotEmpty &&
-        !widget.player.isScrubbing;
+        !widget.player.isScrubbing &&
+        !_isUserSelecting;
     if (shouldTick && !_ticker.isActive) {
       _ticker.start();
     } else if (!shouldTick && _ticker.isActive) {
@@ -1054,30 +1120,33 @@ class _LandscapeLyricPanelState extends State<_LandscapeLyricPanel> {
     final fontSize = widget.compact ? 26.0 : 34.0;
     final inactiveFontSize = widget.compact ? 18.0 : 24.0;
 
-    return LyricView(
-      controller: _lyricController,
-      style: LyricStyles.default1.copyWith(
-        textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
-          color: Colors.white.withValues(alpha: .34),
-          fontSize: inactiveFontSize,
-          height: 1.18,
-          fontWeight: FontWeight.w800,
+    return ExcludeSemantics(
+      // 歌词视图高频更新会触发 Windows AXTree 竞态崩溃，排除语义树
+      child: LyricView(
+        controller: _lyricController,
+        style: LyricStyles.default1.copyWith(
+          textStyle: Theme.of(context).textTheme.titleLarge!.copyWith(
+            color: Colors.white.withValues(alpha: .34),
+            fontSize: inactiveFontSize,
+            height: 1.18,
+            fontWeight: FontWeight.w800,
+          ),
+          activeStyle: Theme.of(context).textTheme.headlineMedium!.copyWith(
+            color: Colors.white.withValues(alpha: .34),
+            fontSize: fontSize,
+            height: 1.18,
+            fontWeight: FontWeight.w900,
+          ),
+          lineGap: widget.compact ? 10 : 16,
+          contentPadding: EdgeInsets.symmetric(
+            horizontal: 24,
+            vertical: widget.compact ? 20 : 40,
+          ),
+          fadeRange: FadeRange(top: 40, bottom: 40),
+          textAlign: TextAlign.left,
+          contentAlignment: CrossAxisAlignment.start,
+          activeHighlightColor: Colors.white,
         ),
-        activeStyle: Theme.of(context).textTheme.headlineMedium!.copyWith(
-          color: Colors.white.withValues(alpha: .34),
-          fontSize: fontSize,
-          height: 1.18,
-          fontWeight: FontWeight.w900,
-        ),
-        lineGap: widget.compact ? 10 : 16,
-        contentPadding: EdgeInsets.symmetric(
-          horizontal: 24,
-          vertical: widget.compact ? 20 : 40,
-        ),
-        fadeRange: FadeRange(top: 40, bottom: 40),
-        textAlign: TextAlign.left,
-        contentAlignment: CrossAxisAlignment.start,
-        activeHighlightColor: Colors.white,
       ),
     );
   }
@@ -1417,50 +1486,53 @@ class _PosterLyricPreviewState extends State<_PosterLyricPreview> {
       fontWeight: FontWeight.w700,
     );
 
-    return SizedBox(
-      height: 96,
-      child: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 260),
-        switchInCurve: Curves.easeOutCubic,
-        switchOutCurve: Curves.easeOutCubic,
-        child: Column(
-          key: ValueKey(current.time.inMilliseconds),
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            SizedBox(
-              height: 36,
-              child: _MarqueeSingleLine(
-                textKey: current.time.inMilliseconds,
-                child: _LyricText(
-                  line: current,
-                  active: true,
-                  position: _position,
-                  styleOverride: currentStyle,
-                  textAlign: TextAlign.center,
-                  singleLine: true,
+    // 歌词预览每帧更新位置，用 ExcludeSemantics 防止 Windows AXTree 竞态崩溃
+    return ExcludeSemantics(
+      child: SizedBox(
+        height: 96,
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 260),
+          switchInCurve: Curves.easeOutCubic,
+          switchOutCurve: Curves.easeOutCubic,
+          child: Column(
+            key: ValueKey(current.time.inMilliseconds),
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                height: 36,
+                child: _MarqueeSingleLine(
+                  textKey: current.time.inMilliseconds,
+                  child: _LyricText(
+                    line: current,
+                    active: true,
+                    position: _position,
+                    styleOverride: currentStyle,
+                    textAlign: TextAlign.center,
+                    singleLine: true,
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 8),
-            SizedBox(
-              height: 25,
-              child: _MarqueeSingleLine(
-                textKey: current.translation != null && current.translation!.isNotEmpty
-                    ? current.time.inMilliseconds
-                    : (next?.time.inMilliseconds ?? -1),
-                child: Text(
-                  current.translation != null && current.translation!.isNotEmpty
-                      ? current.translation!
-                      : (next?.text ?? ''),
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  softWrap: false,
-                  overflow: TextOverflow.visible,
-                  style: nextStyle,
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 25,
+                child: _MarqueeSingleLine(
+                  textKey: current.translation != null && current.translation!.isNotEmpty
+                      ? current.time.inMilliseconds
+                      : (next?.time.inMilliseconds ?? -1),
+                  child: Text(
+                    current.translation != null && current.translation!.isNotEmpty
+                        ? current.translation!
+                        : (next?.text ?? ''),
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    softWrap: false,
+                    overflow: TextOverflow.visible,
+                    style: nextStyle,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -1778,6 +1850,11 @@ class _LyricViewportState extends State<_LyricViewport>
     with SingleTickerProviderStateMixin {
   late final LyricController _lyricController;
   late final Ticker _ticker;
+  // flutter_lyric 内部通过 isSelectingNotifier 标记用户是否在拖动歌词。
+  // LyricView 是 CustomPaint 自绘，不产生 ScrollNotification，外层
+  // NotificationListener 无效；改为监听 isSelectingNotifier 控制 ticker，
+  // 用户拖动时停止 setProgress，避免与 flutter_lyric 内部 fling/恢复竞态。
+  bool _isUserSelecting = false;
 
   @override
   void initState() {
@@ -1786,6 +1863,7 @@ class _LyricViewportState extends State<_LyricViewport>
     _lyricController.setOnTapLineCallback((position) {
       widget.player.seek(position);
     });
+    _lyricController.isSelectingNotifier.addListener(_onSelectingChanged);
     _syncLyrics();
     _ticker = Ticker(_onTick);
     _syncTicker();
@@ -1811,9 +1889,15 @@ class _LyricViewportState extends State<_LyricViewport>
 
   @override
   void dispose() {
+    _lyricController.isSelectingNotifier.removeListener(_onSelectingChanged);
     _ticker.dispose();
     _lyricController.dispose();
     super.dispose();
+  }
+
+  void _onSelectingChanged() {
+    _isUserSelecting = _lyricController.isSelectingNotifier.value;
+    _syncTicker();
   }
 
   void _syncTicker() {
@@ -1821,7 +1905,8 @@ class _LyricViewportState extends State<_LyricViewport>
         widget.isPageVisible &&
         widget.player.isPlaying &&
         widget.lyrics.isNotEmpty &&
-        !widget.player.isScrubbing;
+        !widget.player.isScrubbing &&
+        !_isUserSelecting;
     if (shouldTick && !_ticker.isActive) {
       _ticker.start();
     } else if (!shouldTick && _ticker.isActive) {
@@ -1855,35 +1940,38 @@ class _LyricViewportState extends State<_LyricViewport>
     final activeSize = 34.0 * widget.lyricScale;
     final translationSize = 16.0 * widget.lyricScale;
 
-    return LyricView(
-      controller: _lyricController,
-      style: LyricStyles.default1.copyWith(
-        textStyle: Theme.of(context).textTheme.headlineMedium!.copyWith(
-          color: Colors.white.withValues(alpha: .34),
-          fontSize: normalSize,
-          height: 1.24,
-          fontWeight: FontWeight.w800,
+    return ExcludeSemantics(
+      // 歌词视图高频更新会触发 Windows AXTree 竞态崩溃，排除语义树
+      child: LyricView(
+        controller: _lyricController,
+        style: LyricStyles.default1.copyWith(
+          textStyle: Theme.of(context).textTheme.headlineMedium!.copyWith(
+            color: Colors.white.withValues(alpha: .34),
+            fontSize: normalSize,
+            height: 1.24,
+            fontWeight: FontWeight.w800,
+          ),
+          activeStyle: Theme.of(context).textTheme.headlineMedium!.copyWith(
+            color: Colors.white.withValues(alpha: .34),
+            fontSize: activeSize,
+            height: 1.24,
+            fontWeight: FontWeight.w900,
+          ),
+          translationStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
+            color: Colors.white.withValues(alpha: .54),
+            fontSize: translationSize,
+            height: 1.28,
+            fontWeight: FontWeight.w700,
+          ),
+          lineGap: 28,
+          translationLineGap: 8,
+          contentPadding: const EdgeInsets.fromLTRB(20, 180, 20, 220),
+          fadeRange: FadeRange(top: 80, bottom: 80),
+          textAlign: TextAlign.start,
+          contentAlignment: CrossAxisAlignment.start,
+          activeAnchorPosition: 0.34,
+          activeHighlightColor: Colors.white,
         ),
-        activeStyle: Theme.of(context).textTheme.headlineMedium!.copyWith(
-          color: Colors.white.withValues(alpha: .34),
-          fontSize: activeSize,
-          height: 1.24,
-          fontWeight: FontWeight.w900,
-        ),
-        translationStyle: Theme.of(context).textTheme.titleMedium!.copyWith(
-          color: Colors.white.withValues(alpha: .54),
-          fontSize: translationSize,
-          height: 1.28,
-          fontWeight: FontWeight.w700,
-        ),
-        lineGap: 28,
-        translationLineGap: 8,
-        contentPadding: const EdgeInsets.fromLTRB(20, 180, 20, 220),
-        fadeRange: FadeRange(top: 80, bottom: 80),
-        textAlign: TextAlign.start,
-        contentAlignment: CrossAxisAlignment.start,
-        activeAnchorPosition: 0.34,
-        activeHighlightColor: Colors.white,
       ),
     );
   }
@@ -2165,18 +2253,22 @@ class _Controls extends StatelessWidget {
     final color = bright
         ? Colors.white
         : Theme.of(context).colorScheme.onSurface;
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width > size.height;
 
     return LayoutBuilder(
       builder: (context, constraints) {
         final compact = compactOverride || constraints.maxWidth < 360;
         final dense = denseOverride;
-        final edgeButtonSize = dense ? 34.0 : (compact ? 40.0 : 44.0);
-        final edgeIconSize = dense ? 21.0 : (compact ? 24.0 : 27.0);
-        final skipButtonSize = dense ? 42.0 : (compact ? 50.0 : 56.0);
-        final skipIconSize = dense ? 33.0 : (compact ? 40.0 : 46.0);
-        final playButtonSize = dense ? 58.0 : (compact ? 72.0 : 82.0);
-        final playIconSize = dense ? 46.0 : (compact ? 56.0 : 64.0);
-        final gap = dense ? 3.0 : (compact ? 5.0 : 9.0);
+        // 超大按钮仅在车机模式开启时使用，普通横屏用标准尺寸。
+        final isCar = isLandscape && ThemeController.instance.carModeEnabled;
+        final edgeButtonSize = dense ? 34.0 : (isCar ? 56.0 : (compact ? 40.0 : 44.0));
+        final edgeIconSize = dense ? 21.0 : (isCar ? 34.0 : (compact ? 24.0 : 27.0));
+        final skipButtonSize = dense ? 42.0 : (isCar ? 72.0 : (compact ? 50.0 : 56.0));
+        final skipIconSize = dense ? 33.0 : (isCar ? 54.0 : (compact ? 40.0 : 46.0));
+        final playButtonSize = dense ? 58.0 : (isCar ? 96.0 : (compact ? 72.0 : 82.0));
+        final playIconSize = dense ? 46.0 : (isCar ? 72.0 : (compact ? 56.0 : 64.0));
+        final gap = dense ? 3.0 : (isCar ? 24.0 : (compact ? 5.0 : 9.0));
 
         return Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -2221,7 +2313,7 @@ class _Controls extends StatelessWidget {
                 iconSize: playIconSize,
                 icon: player.isPreparing
                     ? SizedBox.square(
-                        dimension: compact ? 24 : 28,
+                        dimension: isCar ? 36 : (compact ? 24 : 28),
                         child: const CircularProgressIndicator(
                           strokeWidth: 3,
                           color: Colors.white,

--- a/lib/ui/pages/playlist_detail_page.dart
+++ b/lib/ui/pages/playlist_detail_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -698,7 +700,13 @@ class _PlaylistDetailPageState extends State<PlaylistDetailPage> {
       body: AdaptiveContentPadding(
         child: Stack(
         children: [
-          CustomScrollView(
+          // Windows 平台滚动时 sliver item 回收重建会产生大量语义节点更新，
+          // 触发 Flutter Windows 引擎 AXTree 更新 bug（console 提示
+          // "Failed to update ui::AXTree"）。在 Windows 上排除语义树消除提示，
+          // 移动端保留无障碍功能。
+          ExcludeSemantics(
+            excluding: !Platform.isWindows,
+            child: CustomScrollView(
             controller: _scrollController,
             slivers: [
               SliverAppBar(
@@ -875,6 +883,7 @@ class _PlaylistDetailPageState extends State<PlaylistDetailPage> {
                 ],
               ],
             ],
+          ),
           ),
           Positioned(
             left: 0,
@@ -1319,12 +1328,14 @@ class _SongRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return AnimatedBuilder(
-      animation: player,
-      builder: (context, _) {
-        final active = player.currentSong?.hash == song.hash;
-        final activeColor = colorScheme.primary;
-        return InkWell(
+    // 歌曲行响应 player 重建，高频更新会触发 Windows AXTree 竞态崩溃
+    return ExcludeSemantics(
+      child: AnimatedBuilder(
+        animation: player,
+        builder: (context, _) {
+          final active = player.currentSong?.hash == song.hash;
+          final activeColor = colorScheme.primary;
+          return InkWell(
           borderRadius: BorderRadius.circular(16),
           onTap: onTap,
           child: AnimatedContainer(
@@ -1484,7 +1495,8 @@ class _SongRow extends StatelessWidget {
             ),
           ),
         );
-      },
+        },
+      ),
     );
   }
 }

--- a/lib/ui/pages/search_page.dart
+++ b/lib/ui/pages/search_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../controllers/auth_controller.dart';
 import '../../controllers/player_controller.dart';
+import '../../controllers/theme_controller.dart';
 import '../../models/music_models.dart';
 import '../../services/music_api.dart';
 import '../../services/search_history_service.dart';
@@ -14,6 +15,7 @@ import '../widgets/song_action_sheets.dart';
 import '../widgets/toast.dart';
 import '../adaptive_layout.dart';
 import 'artist_detail_page.dart';
+import 'dart:math' as math;
 
 class SearchPage extends StatefulWidget {
   const SearchPage({
@@ -189,9 +191,98 @@ class _SearchPageState extends State<SearchPage> {
     );
   }
 
+  Widget _buildCarSearchHeader(BuildContext context, ColorScheme colorScheme) {
+    return Row(
+      children: [
+        IconButton(
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.arrow_back_ios_new_rounded),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Container(
+            height: 46,
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHighest.withValues(alpha: .54),
+              borderRadius: BorderRadius.circular(23),
+            ),
+            child: TextField(
+              controller: _controller,
+              focusNode: _focusNode,
+              textInputAction: TextInputAction.search,
+              onSubmitted: (_) => _onSubmit(),
+              style: Theme.of(context).textTheme.bodyLarge,
+              decoration: InputDecoration(
+                prefixIcon: Icon(
+                  Icons.search_rounded,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                suffixIcon: _controller.text.isNotEmpty
+                    ? IconButton(
+                        icon: const Icon(Icons.close_rounded),
+                        onPressed: () {
+                          _controller.clear();
+                          _focusNode.requestFocus();
+                        },
+                      )
+                    : null,
+                hintText: '搜索歌曲，歌手',
+                hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
+                border: InputBorder.none,
+                contentPadding: const EdgeInsets.symmetric(vertical: 11),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        ElevatedButton(
+          onPressed: _onSubmit,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: colorScheme.primary,
+            foregroundColor: colorScheme.onPrimary,
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(23),
+            ),
+          ),
+          child: const Text(
+            '搜索',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width > size.height;
     final colorScheme = Theme.of(context).colorScheme;
+    // 车机式搜索栏仅在车机模式开启时使用，普通横屏用标准布局。
+    final isCarMode = isLandscape && ThemeController.instance.carModeEnabled;
+
+    if (isCarMode) {
+      return Scaffold(
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 16),
+            child: Column(
+              children: [
+                _buildCarSearchHeader(context, colorScheme),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: AnimatedBuilder(
+                    animation: widget.auth,
+                    builder: (context, _) => _buildBody(context),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -272,13 +363,8 @@ class _SearchPageState extends State<SearchPage> {
       children: [
         // 平台切换栏（仅搜索状态下显示）
         if (text.isNotEmpty || _searched)
-          _PlatformSelector(
-            platform: _platform,
-            onChanged: _switchPlatform,
-          ),
-        Expanded(
-          child: _buildContent(context, text),
-        ),
+          _PlatformSelector(platform: _platform, onChanged: _switchPlatform),
+        Expanded(child: _buildContent(context, text)),
       ],
     );
   }
@@ -306,6 +392,85 @@ class _SearchPageState extends State<SearchPage> {
       if (_hotLoading) {
         return const _HotSearchSkeleton();
       }
+
+      final size = MediaQuery.sizeOf(context);
+      final isLandscape = size.width > size.height;
+      // 三列热搜布局是车机专属，普通横屏走下面的标准布局。
+      final isCarMode = isLandscape && ThemeController.instance.carModeEnabled;
+
+      if (isCarMode) {
+        return ListView(
+          padding: const EdgeInsets.fromLTRB(0, 8, 0, 16),
+          children: [
+            if (_searchHistory.isNotEmpty) ...[
+              Row(
+                children: [
+                  Text(
+                    '搜索历史',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w900,
+                      fontSize: 18,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  GestureDetector(
+                    onTap: () async {
+                      await _historyService.clear();
+                      _loadSearchHistory();
+                      if (mounted) {
+                        Toast.show('已清空搜索历史', type: ToastType.info);
+                      }
+                    },
+                    child: Icon(
+                      Icons.delete_outline_rounded,
+                      size: 20,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: _searchHistory.map((keyword) {
+                  return _HistoryChip(
+                    keyword: keyword,
+                    onTap: () => _onKeywordTap(keyword),
+                    onDelete: () async {
+                      await _historyService.remove(keyword);
+                      _loadSearchHistory();
+                    },
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 24),
+            ],
+            if (_hotCategories.isNotEmpty) ...[
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (
+                    var i = 0;
+                    i < math.min(3, _hotCategories.length);
+                    i++
+                  ) ...[
+                    Expanded(
+                      child: _CarHotSearchColumn(
+                        category: _hotCategories[i],
+                        onTap: _onKeywordTap,
+                      ),
+                    ),
+                    if (i < math.min(3, _hotCategories.length) - 1)
+                      const SizedBox(width: 24),
+                  ],
+                ],
+              ),
+            ],
+          ],
+        );
+      }
+
       // 历史记录 + 热搜面板共存于一个可滚动列表
       return ListView(
         padding: const EdgeInsets.fromLTRB(18, 8, 18, 160),
@@ -317,9 +482,9 @@ class _SearchPageState extends State<SearchPage> {
                   child: Text(
                     '搜索历史',
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.w900,
-                          fontSize: 20,
-                        ),
+                      fontWeight: FontWeight.w900,
+                      fontSize: 20,
+                    ),
                   ),
                 ),
                 GestureDetector(
@@ -406,19 +571,21 @@ class _PlatformSelector extends StatelessWidget {
                 decoration: BoxDecoration(
                   color: platform == p
                       ? colorScheme.primary
-                      : colorScheme.surfaceContainerHighest.withValues(alpha: .5),
+                      : colorScheme.surfaceContainerHighest.withValues(
+                          alpha: .5,
+                        ),
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Text(
                   p == _SearchPlatform.kugou ? '酷狗' : '网易云',
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: platform == p
-                            ? colorScheme.onPrimary
-                            : colorScheme.onSurfaceVariant,
-                        fontWeight: platform == p
-                            ? FontWeight.w800
-                            : FontWeight.w600,
-                      ),
+                    color: platform == p
+                        ? colorScheme.onPrimary
+                        : colorScheme.onSurfaceVariant,
+                    fontWeight: platform == p
+                        ? FontWeight.w800
+                        : FontWeight.w600,
+                  ),
                 ),
               ),
             ),
@@ -963,16 +1130,18 @@ class _SearchResults extends StatelessWidget {
                                   ),
                                   if (player.downloadController != null)
                                     SongSheetAction(
-                                      icon: player.downloadController!.isDownloaded(song)
+                                      icon:
+                                          player.downloadController!
+                                              .isDownloaded(song)
                                           ? Icons.download_done_rounded
                                           : Icons.download_rounded,
-                                      title: player.downloadController!.isDownloaded(song)
+                                      title:
+                                          player.downloadController!
+                                              .isDownloaded(song)
                                           ? '已下载'
                                           : '下载',
-                                      onTap: () => player.downloadController!.download(
-                                        song,
-                                        player.audioQuality,
-                                      ),
+                                      onTap: () => player.downloadController!
+                                          .download(song, player.audioQuality),
                                     ),
                                 ],
                               );
@@ -989,15 +1158,17 @@ class _SearchResults extends StatelessWidget {
                                 vertical: 3,
                               ),
                               decoration: BoxDecoration(
-                                color: colorScheme.outlineVariant
-                                    .withValues(alpha: .5),
+                                color: colorScheme.outlineVariant.withValues(
+                                  alpha: .5,
+                                ),
                                 borderRadius: BorderRadius.circular(6),
                               ),
                               child: Text(
                                 song.source == SongSource.netease
                                     ? '网易云'
                                     : '外部',
-                                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                                style: Theme.of(context).textTheme.labelSmall
+                                    ?.copyWith(
                                       color: colorScheme.onSurfaceVariant,
                                       fontWeight: FontWeight.w700,
                                     ),
@@ -1085,9 +1256,9 @@ class _HistoryChip extends StatelessWidget {
             children: [
               Text(
                 keyword,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
               ),
               const SizedBox(width: 4),
               GestureDetector(
@@ -1105,6 +1276,73 @@ class _HistoryChip extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _CarHotSearchColumn extends StatelessWidget {
+  const _CarHotSearchColumn({required this.category, required this.onTap});
+
+  final SearchHotCategory category;
+  final ValueChanged<String> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          category.name,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w900,
+            color: colorScheme.onSurface,
+          ),
+        ),
+        const SizedBox(height: 12),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: math.min(6, category.keywords.length),
+          itemBuilder: (context, index) {
+            final item = category.keywords[index];
+            final rank = index + 1;
+            return InkWell(
+              onTap: () => onTap(item.keyword),
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 24,
+                      child: Text(
+                        '$rank',
+                        style: TextStyle(
+                          fontWeight: rank <= 3
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                          color: rank <= 3
+                              ? Colors.redAccent
+                              : colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Text(
+                        item.keyword,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontWeight: FontWeight.w500),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -113,6 +113,15 @@ class SettingsPage extends StatelessWidget {
                       onChanged: player.setSmartQualityEnabled,
                     ),
                     _SettingsDivider(),
+                    _SettingsSwitchTile(
+                      icon: Icons.power_settings_new_rounded,
+                      iconColor: colorScheme.primary,
+                      title: '开机自启播放',
+                      subtitle: '打开应用时自动加载并播放推荐歌单',
+                      value: player.autoPlayOnStartupEnabled,
+                      onChanged: player.setAutoPlayOnStartupEnabled,
+                    ),
+                    _SettingsDivider(),
                     _SettingsTile(
                       icon: Icons.graphic_eq_rounded,
                       iconColor: colorScheme.primary,
@@ -287,6 +296,15 @@ class SettingsPage extends StatelessWidget {
                       onChanged: (value) {
                         theme.setLandscapeEnabled(value, AdaptiveLayout.isTablet(context));
                       },
+                    ),
+                    _SettingsDivider(),
+                    _SettingsSwitchTile(
+                      icon: Icons.directions_car_rounded,
+                      iconColor: colorScheme.primary,
+                      title: '车机模式',
+                      subtitle: '横屏时使用左侧播放面板布局并放大文字',
+                      value: theme.carModeEnabled,
+                      onChanged: (value) => theme.setCarModeEnabled(value),
                     ),
                   ],
                 ),

--- a/lib/ui/widgets/car_left_player_panel.dart
+++ b/lib/ui/widgets/car_left_player_panel.dart
@@ -1,0 +1,495 @@
+import 'package:flutter/material.dart';
+import '../../controllers/auth_controller.dart';
+import '../../controllers/player_controller.dart';
+import '../../models/music_models.dart';
+import '../pages/player_page.dart';
+import 'artwork.dart';
+import 'toast.dart';
+
+class CarLeftPlayerPanel extends StatelessWidget {
+  const CarLeftPlayerPanel({
+    super.key,
+    required this.player,
+    required this.auth,
+  });
+
+  final PlayerController player;
+  final AuthController auth;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final isSmallScreen = size.width < 960;
+    final panelWidth = isSmallScreen ? 320.0 : 380.0;
+    final panelPadding = isSmallScreen ? 14.0 : 20.0;
+
+    if (size.height < 150) {
+      return SizedBox(width: panelWidth);
+    }
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return AnimatedBuilder(
+      animation: player,
+      builder: (context, _) {
+        final song = player.currentSong;
+        if (song == null) {
+          final height = MediaQuery.sizeOf(context).height;
+          final verticalPadding = height < 400 ? 10.0 : 24.0;
+          final sysPadding = MediaQuery.paddingOf(context);
+          return Container(
+            width: panelWidth,
+            color: isDark
+                ? colorScheme.surfaceContainerLow
+                : const Color(0xFFF2F4F7),
+            padding: EdgeInsets.fromLTRB(
+              panelPadding,
+              sysPadding.top + verticalPadding,
+              panelPadding,
+              sysPadding.bottom + verticalPadding,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildHeader(context, colorScheme),
+                const Expanded(
+                  child: Center(
+                    child: Text(
+                      '暂无播放歌曲',
+                      style: TextStyle(color: Colors.grey, fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return AnimatedBuilder(
+          animation: auth,
+          builder: (context, _) {
+            final liked = auth.isLiked(song);
+            final height = MediaQuery.sizeOf(context).height;
+            final sysPadding = MediaQuery.paddingOf(context);
+            final availableHeight = height - sysPadding.top - sysPadding.bottom;
+
+            final isShortScreen = height < 500;
+            final verticalPadding = isShortScreen ? 8.0 : 20.0;
+            final bottomGap = isShortScreen ? 10.0 : 32.0;
+            final controlsHeight = isShortScreen ? 68.0 : 80.0;
+
+            final artworkSizeSubtractor = isShortScreen ? 250.0 : 340.0;
+            final artworkSize = (availableHeight - artworkSizeSubtractor).clamp(80.0, 280.0);
+
+            final gapSize = isShortScreen ? 10.0 : 20.0;
+            final titleGap = isShortScreen ? 14.0 : 24.0;
+            final progressGap = isShortScreen ? 16.0 : 28.0;
+
+            final buttonMinWidth = isSmallScreen ? 42.0 : 52.0;
+            final playBtnSize = isSmallScreen ? 56.0 : 64.0;
+            final playIconSize = isSmallScreen ? 32.0 : 40.0;
+
+            return Container(
+              width: panelWidth,
+              // 加上状态栏（top）和车机系统栏（bottom）的高度，避免被系统 UI 隐藏
+              padding: EdgeInsets.fromLTRB(
+                panelPadding,
+                sysPadding.top + verticalPadding,
+                panelPadding,
+                sysPadding.bottom + verticalPadding,
+              ),
+              color: isDark
+                  ? colorScheme.surfaceContainerLow
+                  : const Color(0xFFF2F4F7), // Light grey background
+              child: ClipRect(
+                child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildHeader(context, colorScheme),
+                  const Spacer(),
+                  // Album Art
+                  Center(
+                    child: GestureDetector(
+                      onTap: () => Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (_) => PlayerPage(player: player, auth: auth),
+                        ),
+                      ),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(16),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: 0.12),
+                              blurRadius: 16,
+                              offset: const Offset(0, 8),
+                            ),
+                          ],
+                        ),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(16),
+                          child: Artwork(
+                            url: song.coverUrl,
+                            size: artworkSize,
+                            borderRadius: 16,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: gapSize),
+                  // Title + Artist + Heart
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              song.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w900,
+                                    fontSize: 18,
+                                  ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              song.artist,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: song.source == SongSource.kugou
+                            ? () => auth.toggleLike(song)
+                            : null,
+                        icon: Icon(
+                          liked ? Icons.favorite_rounded : Icons.favorite_border_rounded,
+                          color: liked ? Colors.redAccent : colorScheme.onSurfaceVariant,
+                          size: 26,
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: titleGap),
+                  // Progress Bar
+                  Builder(
+                    builder: (context) {
+                      final duration = player.duration;
+                      final position = player.smoothPosition;
+                      final max = duration.inMilliseconds <= 0
+                          ? 1.0
+                          : duration.inMilliseconds.toDouble();
+                      final value = position.inMilliseconds
+                          .clamp(0, max.toInt())
+                          .toDouble();
+
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SliderTheme(
+                            data: SliderTheme.of(context).copyWith(
+                              trackHeight: 3,
+                              thumbShape: const RoundSliderThumbShape(
+                                enabledThumbRadius: 5,
+                              ),
+                              overlayShape: const RoundSliderOverlayShape(
+                                overlayRadius: 10,
+                              ),
+                              activeTrackColor: colorScheme.primary,
+                              inactiveTrackColor: isDark
+                                  ? Colors.white.withValues(alpha: 0.16)
+                                  : Colors.black.withValues(alpha: 0.08),
+                              thumbColor: colorScheme.primary,
+                            ),
+                            child: Slider(
+                              value: value,
+                              max: max,
+                              onChanged: (val) =>
+                                  player.previewSeek(Duration(milliseconds: val.round())),
+                              onChangeEnd: (val) =>
+                                  player.seek(Duration(milliseconds: val.round())),
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                _formatDuration(position),
+                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: colorScheme.onSurfaceVariant,
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                              ),
+                              Text(
+                                _formatDuration(duration),
+                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: colorScheme.onSurfaceVariant,
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  SizedBox(height: progressGap),
+                  Container(
+                    height: controlsHeight,
+                    decoration: BoxDecoration(
+                      color: isDark
+                          ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.8)
+                          : Colors.black.withValues(alpha: 0.06),
+                      borderRadius: BorderRadius.circular(40),
+                    ),
+                    padding: EdgeInsets.symmetric(horizontal: isSmallScreen ? 8 : 12),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        // Loop mode
+                        IconButton(
+                          padding: EdgeInsets.zero,
+                          constraints: BoxConstraints(minWidth: buttonMinWidth, minHeight: buttonMinWidth),
+                          icon: Icon(
+                            _getPlaybackModeIcon(player.playbackMode),
+                            size: isSmallScreen ? 24 : 28,
+                            color: colorScheme.onSurface,
+                          ),
+                          onPressed: player.cyclePlaybackMode,
+                        ),
+                        // Prev
+                        IconButton(
+                          padding: EdgeInsets.zero,
+                          constraints: BoxConstraints(minWidth: buttonMinWidth, minHeight: buttonMinWidth),
+                          icon: Icon(
+                            Icons.skip_previous_rounded,
+                            size: isSmallScreen ? 30 : 36,
+                            color: colorScheme.onSurface,
+                          ),
+                          onPressed: player.isPreparing ? null : player.previous,
+                        ),
+                        // Play/Pause (large circle/white or themed)
+                        Container(
+                          width: playBtnSize,
+                          height: playBtnSize,
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            shape: BoxShape.circle,
+                          ),
+                          child: IconButton(
+                            padding: EdgeInsets.zero,
+                            icon: Icon(
+                              player.isPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded,
+                              color: colorScheme.onPrimary,
+                              size: playIconSize,
+                            ),
+                            onPressed: player.isPreparing ? null : player.togglePlay,
+                          ),
+                        ),
+                        // Next
+                        IconButton(
+                          padding: EdgeInsets.zero,
+                          constraints: BoxConstraints(minWidth: buttonMinWidth, minHeight: buttonMinWidth),
+                          icon: Icon(
+                            Icons.skip_next_rounded,
+                            size: isSmallScreen ? 30 : 36,
+                            color: colorScheme.onSurface,
+                          ),
+                          onPressed: player.isPreparing ? null : player.next,
+                        ),
+                        // Queue
+                        IconButton(
+                          padding: EdgeInsets.zero,
+                          constraints: BoxConstraints(minWidth: buttonMinWidth, minHeight: buttonMinWidth),
+                          icon: Icon(
+                            Icons.queue_music_rounded,
+                            size: isSmallScreen ? 24 : 28,
+                            color: colorScheme.onSurface,
+                          ),
+                          onPressed: () => _showQueue(context),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Spacer(),
+                  SizedBox(height: bottomGap),
+                ],
+              ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, ColorScheme colorScheme) {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            color: colorScheme.primary.withValues(alpha: 0.15),
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.music_note_rounded,
+            color: colorScheme.primary,
+            size: 18,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          'KA Music',
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w900,
+                color: colorScheme.onSurface,
+              ),
+        ),
+      ],
+    );
+  }
+
+  IconData _getPlaybackModeIcon(PlaybackMode mode) {
+    return switch (mode) {
+      PlaybackMode.playlistLoop => Icons.repeat_rounded,
+      PlaybackMode.shuffle => Icons.shuffle_rounded,
+      PlaybackMode.singleLoop => Icons.repeat_one_rounded,
+    };
+  }
+
+  void _showQueue(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      builder: (sheetContext) {
+        final colorScheme = Theme.of(sheetContext).colorScheme;
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 18),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Row(
+                    children: [
+                      Text(
+                        '播放队列',
+                        style: Theme.of(sheetContext)
+                            .textTheme
+                            .titleLarge
+                            ?.copyWith(fontWeight: FontWeight.w900),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        '${player.queue.length} 首',
+                        style: Theme.of(sheetContext).textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                      ),
+                      const Spacer(),
+                      TextButton(
+                        onPressed: player.queue.length > 1
+                            ? () {
+                                final current = player.currentSong;
+                                if (current == null) return;
+                                Navigator.of(sheetContext).pop();
+                                player.playSong(current, queue: [current]);
+                                Toast.success('已清空播放队列');
+                              }
+                            : null,
+                        child: Text(
+                          '清空',
+                          style: TextStyle(color: colorScheme.error),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Flexible(
+                  child: AnimatedBuilder(
+                    animation: player,
+                    builder: (context, _) {
+                      if (player.queue.isEmpty) {
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 32),
+                          child: Center(
+                            child: Text(
+                              '播放队列为空',
+                              style: Theme.of(sheetContext)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                            ),
+                          ),
+                        );
+                      }
+                      return ListView.separated(
+                        shrinkWrap: true,
+                        itemCount: player.queue.length,
+                        separatorBuilder: (_, _) => const SizedBox(height: 2),
+                        itemBuilder: (context, index) {
+                          final song = player.queue[index];
+                          final active = player.currentSong?.hash == song.hash;
+                          return ListTile(
+                            selected: active,
+                            leading: Artwork(url: song.coverUrl, size: 40, borderRadius: 8),
+                            title: Text(
+                              song.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                color: active ? colorScheme.primary : null,
+                                fontWeight: active ? FontWeight.bold : null,
+                              ),
+                            ),
+                            subtitle: Text(song.artist),
+                            trailing: active
+                                ? Icon(
+                                    player.isPlaying ? Icons.equalizer_rounded : Icons.pause_rounded,
+                                    color: colorScheme.primary,
+                                  )
+                                : null,
+                            onTap: () {
+                              Navigator.of(sheetContext).pop();
+                              player.playSong(song, queue: player.queue);
+                            },
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _formatDuration(Duration d) {
+    if (d == Duration.zero) return '00:00';
+    final minutes = d.inMinutes.toString().padLeft(2, '0');
+    final seconds = (d.inSeconds % 60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  }
+}

--- a/lib/ui/widgets/mini_player.dart
+++ b/lib/ui/widgets/mini_player.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../controllers/auth_controller.dart';
 import '../../controllers/player_controller.dart';
+import '../../controllers/theme_controller.dart';
 import '../../models/music_models.dart';
 import '../pages/player_page.dart';
 import 'artwork.dart';
@@ -17,13 +18,23 @@ class MiniPlayer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: player,
-      builder: (context, _) {
-        final song = player.currentSong;
-        if (song == null) {
-          return const SizedBox.shrink();
-        }
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width > size.height;
+    // 仅车机模式隐藏（由左侧播放面板替代）；普通横屏仍显示。
+    if (isLandscape && ThemeController.instance.carModeEnabled) {
+      return const SizedBox.shrink();
+    }
+
+    // MiniPlayer 响应 player 重建（进度/状态），高频更新会触发
+    // Windows AXTree 竞态崩溃，排除语义树以规避 Flutter Windows 引擎 bug
+    return ExcludeSemantics(
+      child: AnimatedBuilder(
+        animation: player,
+        builder: (context, _) {
+          final song = player.currentSong;
+          if (song == null) {
+            return const SizedBox.shrink();
+          }
 
         final progress = player.duration.inMilliseconds == 0
             ? 0.0
@@ -180,7 +191,8 @@ class MiniPlayer extends StatelessWidget {
             ),
           ),
         );
-      },
+        },
+      ),
     );
   }
 

--- a/lib/ui/widgets/song_action_sheets.dart
+++ b/lib/ui/widgets/song_action_sheets.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../controllers/auth_controller.dart';
 import '../../controllers/player_controller.dart';
+import '../../controllers/theme_controller.dart';
 import '../../models/music_models.dart';
 import 'artwork.dart';
 import 'toast.dart';
@@ -31,6 +32,50 @@ Future<void> showSongActionSheet({
   required Song song,
   required List<SongSheetAction> actions,
 }) {
+  final isLandscape = MediaQuery.sizeOf(context).width > MediaQuery.sizeOf(context).height;
+  // 左侧滑入弹窗是车机专属交互，普通横屏用标准底部弹窗。
+  final isCarMode = isLandscape && ThemeController.instance.carModeEnabled;
+
+  if (isCarMode) {
+    return showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Dismiss',
+      barrierColor: Colors.black.withValues(alpha: 0.5),
+      transitionDuration: const Duration(milliseconds: 280),
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return Align(
+          alignment: Alignment.centerLeft,
+          child: Container(
+            margin: const EdgeInsets.only(left: 24, top: 24, bottom: 24),
+            width: 320,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.2),
+                  blurRadius: 15,
+                  offset: const Offset(5, 5),
+                ),
+              ],
+            ),
+            child: _buildCarActionDialogContent(context, song, actions),
+          ),
+        );
+      },
+      transitionBuilder: (context, animation, secondaryAnimation, child) {
+        return SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(-1.0, 0.0),
+            end: Offset.zero,
+          ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic)),
+          child: child,
+        );
+      },
+    );
+  }
+
   final gridActions = actions.where((a) => a.isGrid).toList();
   final listActions = actions.where((a) => !a.isGrid).toList();
 
@@ -49,86 +94,86 @@ Future<void> showSongActionSheet({
               children: [
                 // Song info
                 Row(
-                children: [
-                  Artwork(url: song.coverUrl, size: 52, borderRadius: 10),
-                  const SizedBox(width: 12),
-                  Expanded(
+                  children: [
+                    Artwork(url: song.coverUrl, size: 52, borderRadius: 10),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            song.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(sheetContext).textTheme.titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w800),
+                          ),
+                          const SizedBox(height: 3),
+                          Text(
+                            song.artist,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(sheetContext).textTheme.bodyMedium
+                                ?.copyWith(color: colorScheme.onSurfaceVariant),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                // Actions card (grid + list in one unified card)
+                if (gridActions.isNotEmpty || listActions.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Material(
+                    color: colorScheme.surfaceContainer,
+                    borderRadius: BorderRadius.circular(16),
+                    clipBehavior: Clip.antiAlias,
                     child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
                       children: [
-                        Text(
-                          song.title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(sheetContext).textTheme.titleMedium
-                              ?.copyWith(fontWeight: FontWeight.w800),
-                        ),
-                        const SizedBox(height: 3),
-                        Text(
-                          song.artist,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(sheetContext).textTheme.bodyMedium
-                              ?.copyWith(color: colorScheme.onSurfaceVariant),
-                        ),
+                        // Grid actions (icon + text, 3-column grid)
+                        if (gridActions.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              vertical: 10,
+                              horizontal: 12,
+                            ),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                for (var row = 0;
+                                    row * 3 < gridActions.length;
+                                    row++)
+                                  Row(
+                                    children: [
+                                      for (var col = 0; col < 3; col++)
+                                        Expanded(
+                                          child: row * 3 + col < gridActions.length
+                                              ? _GridItem(
+                                                  action: gridActions[row * 3 + col],
+                                                )
+                                              : const SizedBox.shrink(),
+                                        ),
+                                    ],
+                                  ),
+                              ],
+                            ),
+                          ),
+                        // Divider between grid and list
+                        if (gridActions.isNotEmpty && listActions.isNotEmpty)
+                          const Divider(height: 1, indent: 16, endIndent: 16),
+                        // List actions
+                        for (var index = 0;
+                            index < listActions.length;
+                            index++) ...[
+                          _SongActionTile(action: listActions[index]),
+                          if (index != listActions.length - 1)
+                            const Divider(height: 1, indent: 58),
+                        ],
                       ],
                     ),
                   ),
                 ],
-              ),
-              // Actions card (grid + list in one unified card)
-              if (gridActions.isNotEmpty || listActions.isNotEmpty) ...[
-                const SizedBox(height: 16),
-                Material(
-                  color: colorScheme.surfaceContainer,
-                  borderRadius: BorderRadius.circular(16),
-                  clipBehavior: Clip.antiAlias,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      // Grid actions (icon + text, 3-column grid)
-                      if (gridActions.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                            vertical: 10,
-                            horizontal: 12,
-                          ),
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              for (var row = 0;
-                                  row * 3 < gridActions.length;
-                                  row++)
-                                Row(
-                                  children: [
-                                    for (var col = 0; col < 3; col++)
-                                      Expanded(
-                                        child: row * 3 + col < gridActions.length
-                                            ? _GridItem(
-                                                action: gridActions[row * 3 + col],
-                                              )
-                                            : const SizedBox.shrink(),
-                                      ),
-                                  ],
-                                ),
-                            ],
-                          ),
-                        ),
-                      // Divider between grid and list
-                      if (gridActions.isNotEmpty && listActions.isNotEmpty)
-                        const Divider(height: 1, indent: 16, endIndent: 16),
-                      // List actions
-                      for (var index = 0;
-                          index < listActions.length;
-                          index++) ...[
-                        _SongActionTile(action: listActions[index]),
-                        if (index != listActions.length - 1)
-                          const Divider(height: 1, indent: 58),
-                      ],
-                    ],
-                  ),
-                ),
-              ],
               ],
             ),
           ),
@@ -320,6 +365,139 @@ class _SongActionTile extends StatelessWidget {
           () => action.onTap(),
         );
       },
+    );
+  }
+}
+
+Widget _buildCarActionDialogContent(
+  BuildContext context,
+  Song song,
+  List<SongSheetAction> actions,
+) {
+  final colorScheme = Theme.of(context).colorScheme;
+  return Material(
+    color: Colors.transparent,
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              IconButton(
+                onPressed: () => Navigator.of(context).pop(),
+                icon: const Icon(Icons.close_rounded),
+                style: IconButton.styleFrom(
+                  backgroundColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      song.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    Text(
+                      song.artist,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Flexible(
+            child: GridView.builder(
+              shrinkWrap: true,
+              itemCount: actions.length,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                mainAxisSpacing: 10,
+                crossAxisSpacing: 10,
+                childAspectRatio: 1.35,
+              ),
+              itemBuilder: (context, index) {
+                final action = actions[index];
+                return _CarGridActionItem(action: action);
+              },
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+class _CarGridActionItem extends StatelessWidget {
+  const _CarGridActionItem({required this.action});
+
+  final SongSheetAction action;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final color = action.danger ? colorScheme.error : colorScheme.onSurface;
+
+    return Material(
+      color: colorScheme.surfaceContainer,
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).pop();
+          Future<void>.delayed(
+            const Duration(milliseconds: 120),
+            () => action.onTap(),
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 8),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(action.icon, color: color, size: 22),
+              const SizedBox(height: 6),
+              Text(
+                action.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w700,
+                  fontSize: 12,
+                ),
+              ),
+              if (action.subtitle != null)
+                Text(
+                  action.subtitle!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    fontSize: 9,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -384,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.16"
+  just_audio_windows:
+    dependency: "direct main"
+    description:
+      name: just_audio_windows
+      sha256: "7d80dfa02a2189f1c26673a56f4d8584a306d3f22735302be6111e9578a40318"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   audio_session: ^0.1.25
   http: ^1.5.0
   just_audio: ^0.10.4
+  just_audio_windows: ^0.2.3
   shared_preferences: ^2.5.3
   url_launcher: ^6.3.2
   dio: ^5.7.0

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -39,7 +39,7 @@ add_definitions(-DUNICODE -D_UNICODE)
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
-  target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100" /utf-8)
   target_compile_options(${TARGET} PRIVATE /EHsc)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_windows/file_selector_windows.h>
+#include <just_audio_windows/just_audio_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  JustAudioWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("JustAudioWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
+  just_audio_windows
   url_launcher_windows
 )
 


### PR DESCRIPTION
## 概述
为车机（Android Automotive / 车载 IVI）场景新增**可选的车机模式**，并附带若干通用稳定性改进。

**车机模式默认关闭**（官方 Android Automotive 设备首次安装自动开启）。开启后横屏启用左侧常驻播放面板布局；**关闭时所有用户（含平板横屏）的体验与原项目完全一致**——所有车机专属 UI 改动都受车机模式开关保护，普通横屏不会触发。本 PR 不改动平板横屏体验。

## 车机模式（核心，可选功能）
新增「车机模式」开关（设置 → 个性化）：
- **自动检测**：通过 `FEATURE_AUTOMOTIVE` 识别官方 Android Automotive 设备，首次安装自动开启(为防止误判牵连平板，国产车机多数不识别）；用户手动开关后永久记住选择
- **横屏布局**：左侧常驻播放面板（封面/进度/控制/循环/收藏/队列）+ 右侧顶栏（搜索/Tab/设置）+ 内容区
- **文字放大** 1.12 倍（保留系统无障碍设置，适合远距离观看）
- **内层 Navigator + PopScope**：拦截返回键，先 pop 内层页面，无法 pop 才退出 App
- 各页面车机专属样式（首页快捷入口/歌单网格/电台布局、搜索车机栏与三列热搜、播放页超大按钮与分栏、歌曲操作左侧滑入弹窗、专辑多列等）**仅在车机模式开启时生效**

## 通用改动（与车机模式独立，始终生效）
- **开机自启播放**：新增独立开关，首次加载后自动播放每日推荐
- **Windows 桌面播放支持**：新增 `just_audio_windows`，CMake 加 `/utf-8`
- **稳定性**：多处 `ExcludeSemantics` 规避 Windows AXTree 崩溃；切歌竞态防护与 completed 延迟，避免 "Lost connection to device"
- **播放历史**：新增轻量 `count()`

## 关键文件
| 文件 | 说明 |
|------|------|
| lib/ui/pages/app_shell.dart | 车机布局入口（`isLandscape && carModeEnabled`）+ 顶栏 + 内层 Navigator |
| lib/ui/widgets/car_left_player_panel.dart | 新增：车机左侧常驻播放面板 |
| lib/controllers/theme_controller.dart | carModeEnabled 开关 + detectAutomotive 车机检测缓存 |
| lib/services/device_info_service.dart | 新增：车机检测 Service（FEATURE_AUTOMOTIVE） |
| android/.../MainActivity.kt | 方向盘 MEDIA_NEXT + `kgka_music_hl/device` 通道 |
| lib/ui/pages/home_page.dart | 首页车机专属布局（受车机模式保护） |
| lib/ui/pages/player_page.dart | 播放页分栏与超大按钮（受车机模式保护） |
| lib/ui/pages/search_page.dart | 车机搜索栏与三列热搜（受车机模式保护） |
| 其他 | library/album_shop/mini_player/song_action_sheets/adaptive_layout 的车机判断 |

## 测试建议
1. **默认行为回归（最重要）**：不开启车机模式，验证竖屏底部导航、横屏 NavigationRail、各页面布局与原项目一致——所有车机样式不应出现
2. **车机模式**：开启后横屏出现左面板+顶栏，首页快捷入口/歌单网格/电台/搜索/播放页/歌曲操作弹窗均用车机样式；竖屏仍正常
3. **返回键**：车机模式下进入歌单/搜索/设置，返回键回上一页而非退出 App
4. **车机检测**：官方 Android Automotive 设备首次安装应自动开启车机模式
5. **开机自启**：独立开关，重启验证
6. **Windows 桌面**：播放/切歌不崩溃、中文歌词正常

更新(da94cc1)
修复:车机横屏切歌后歌词不刷新——_LandscapeLyricPanel 原用 listEquals 比较 player.lyrics,切歌时引用未变不触发重载;改为把 songHash/lyrics 作为显式参数传入,靠参数变化驱动重载。
移除:方向盘 MEDIA_NEXT 长按暂停功能(实机不可靠)。MEDIA_NEXT 恢复为 audio_service 默认行为(短按下一首)。