### PR TITLE
fix(login): 修复扫码登录两个问题（状态码映射 + 深色模式二维码）

### DIFF
--- a/lib/models/music_models.dart
+++ b/lib/models/music_models.dart
@@ -1642,10 +1642,11 @@ class QrCheckResult {
   final String? nickname;
   final String? avatar;
 
-  // 酷狗二维码状态码：0=等待扫码, 1=已扫码待确认, 2=已过期, 4=登录成功
-  bool get isWaitingForScan => status == 0;
-  bool get isWaitingForConfirm => status == 1;
-  bool get isExpired => status == 2;
+  // 酷狗概念版二维码状态码（参考 jsososo/kugou-concept、ImUpXuu/KuGouWebPlayer）：
+  //   0 = 已过期        1 = 等待扫码        2 = 已扫码待确认        4 = 登录成功
+  bool get isWaitingForScan => status == 1;
+  bool get isWaitingForConfirm => status == 2;
+  bool get isExpired => status == 0;
   bool get isSuccess => status == 4 && token != null && token!.isNotEmpty;
 
   factory QrCheckResult.fromJson(Map<String, dynamic> json) {

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -1106,6 +1106,19 @@ class _QrImage extends StatelessWidget {
           ),
         );
 
+    // 二维码的“白色”区域在 PNG 里通常是透明的。深色模式下，透明的“白”
+    // 区域会透出底层近黑的 surface，使二维码变成黑底黑码，手机无法识别。
+    // 因此这里始终垫一层纯白背景，保证高对比度，与主题无关。
+    Widget withWhiteBackground(Widget image) => Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: image,
+        );
+
     final uri = Uri.tryParse(imageUrl);
     if (uri == null) return fallback();
 
@@ -1114,21 +1127,25 @@ class _QrImage extends StatelessWidget {
     if (data != null) {
       final bytes = data.contentAsBytes();
       if (bytes.isEmpty) return fallback();
-      return Image.memory(
-        bytes,
+      return withWhiteBackground(
+        Image.memory(
+          bytes,
+          width: size,
+          height: size,
+          fit: BoxFit.contain,
+          errorBuilder: (_, __, ___) => fallback(),
+        ),
+      );
+    }
+
+    return withWhiteBackground(
+      Image.network(
+        imageUrl,
         width: size,
         height: size,
         fit: BoxFit.contain,
         errorBuilder: (_, __, ___) => fallback(),
-      );
-    }
-
-    return Image.network(
-      imageUrl,
-      width: size,
-      height: size,
-      fit: BoxFit.contain,
-      errorBuilder: (_, __, ___) => fallback(),
+      ),
     );
   }
 }


### PR DESCRIPTION
## 修复内容

本 PR 修复扫码登录页面的两个 bug。

### 1. 二维码状态码语义映射反了（功能性 bug，影响所有用户）

`QrCheckResult`（`lib/models/music_models.dart`）里酷狗概念版二维码状态码的语义注释和 getter 实现是反的：

| status | 原错误映射 | 正确映射 |
|:-:|:-:|:-:|
| `0` | 等待扫码 | **已过期** |
| `1` | 已扫码待确认 | **等待扫码** |
| `2` | 已过期 | **已扫码待确认** |
| `4` | 登录成功 | 登录成功 ✓ |

**现象**：用户进入扫码页（还没扫码）就被提示「扫码成功，请在手机上确认」，随后二维码又立刻显示「已过期」。原因：首次轮询返回 `status=1`（其实是「等待扫码」）被误判为「已扫码待确认」；状态推进到 `2`（其实是「待确认」）又被误判为「已过期」而停止轮询。

**正确语义参考**：[jsososo/kugou-concept](https://github.com/jsososo/kugou-concept)、[ImUpXuu/KuGouWebPlayer](https://github.com/ImUpXuu/KuGouWebPlayer) 的状态码定义。

得益于使用语义 getter（`isExpired` 等），`login_page.dart` 的轮询分支无需改动，getter 含义一纠正所有调用点自动正确。

### 2. 深色模式下二维码无法被手机识别（UI bug）

**现象**：深色模式下，用户用酷狗 App 扫屏幕上的二维码扫不出来。

**原因**：服务器返回的二维码是 `data:image/png;base64` 形式的 PNG，其「白色」区域通常是透明的。深色模式下父容器 `surface` 近黑（约 `#0B0C10`），`_QrImage` 内 `Image.memory` 没有背景层，透明的「白」区域透出底层近黑色，二维码变成黑底黑码，手机相机无法识别对比度。

**修复**：在 `_QrImage.build()` 内提取 `withWhiteBackground()`，给 `Image.memory` / `Image.network` 垫一层纯白背景（圆角 16 与外层 `ClipRRect` 对齐）。背景色固定白色——二维码规范要求黑码点白底，对比度越高越易识别，不应受应用主题影响。

## 测试

- [x] 浅色模式：扫码流程正常，文案流转「请使用酷狗 App 扫码 → 扫码成功，请在手机上确认 → 登录成功」
- [x] 深色模式：二维码可见白底黑码，手机可正常识别
- [x] 二维码真正过期（约 1-2 分钟后）才显示「已过期」并停止轮询

## 改动文件

- `lib/models/music_models.dart` — 修正 `QrCheckResult` 状态码语义映射（4 个 getter）
- `lib/ui/pages/login_page.dart` — `_QrImage` 增加纯白背景层