### PR TITLE
feat: 集成 SuperLyricApi 系统歌词发布与车载蓝牙歌词广播

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,7 +48,13 @@ android {
         applicationId = "com.hoilai.mm.music"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        // 不能用 flutter.minSdkVersion（CI 的 Flutter 3.47.1 解析为 24）：
+        // 车载歌词依赖 SuperLyricApi 3.4 的 AAR 清单声明 minSdk 26（Android 8.0），
+        // 低于 26 会在 Manifest 合并阶段直接失败：
+        //   "uses-sdk:minSdkVersion 24 cannot be smaller than version 26 declared
+        //    in library com.github.HChenX:SuperLyricApi"
+        // Android 8.0（2017 年发布）覆盖 99%+ 活跃设备，直接提到 26。
+        minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
@@ -72,6 +78,21 @@ android {
                 abiFilters.clear()
                 abiFilters.add("arm64-v8a")
             }
+            isMinifyEnabled = false
+            // Flutter Gradle 插件在 apply 阶段（早于本脚本体执行）会默认打开
+            // release.shrinkResources = true（见 FlutterPluginUtils.shouldShrinkResources，
+            // 无 -Pshrink 属性时恒为 true）。如果我们只关 minify 而不关 shrinkResources，
+            // AGP 配置期会直接报错：
+            //   "Removing unused resources requires unused code shrinking to be turned on"
+            // 因此必须成对显式关闭。
+            isShrinkResources = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug {
+            isMinifyEnabled = false
         }
     }
 }
@@ -81,6 +102,28 @@ kotlin {
     }
 }
 
+
+// === 依赖解析策略：对 JitPack 等按需构建的仓库不缓存失败结果，确保一次冷启动失败后
+// 等若干秒再次构建时能重新尝试拉取（而不是被 Gradle 本地缓存的 "404 / module not found"
+// 结果一直挡住）。
+configurations.all {
+    resolutionStrategy {
+        // changing 模块（例如 JitPack 的版本号固定但 artifact 是懒构建）不缓存
+        cacheChangingModulesFor(0, "seconds")
+        // 动态版本（1.+、[1.0, 2.0) 等）不缓存，本项目未用，保留默认即可。
+    }
+}
+
+dependencies {
+    // SuperLyricApi（https://github.com/HChenX/SuperLyricApi 3.4）
+    // AAR 通过 JitPack 发布。JitPack 是"首次请求时才在服务器端懒构建"，
+    // 所以把该依赖标记为 `changing = true`，配合上面的
+    // `cacheChangingModulesFor(0 seconds)` 让 Gradle 不会永远缓存首次 404。
+    // 同时在 CI workflow 里做了 JitPack 冷启动失败 → sleep 90s → 重试的兜底。
+    implementation("com.github.HChenX:SuperLyricApi:3.4") {
+        isChanging = true
+    }
+}
 
 flutter {
     source = "../.."

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# SuperLyricApi 混淆规则
+-keep class com.hchen.superlyricapi.** { *; }

--- a/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
@@ -11,9 +11,11 @@ import android.content.pm.PackageManager
 import android.database.Cursor
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
 import android.provider.Settings
+import android.util.Log
 import android.media.audiofx.BassBoost
 import android.media.audiofx.Equalizer
 import android.media.audiofx.DynamicsProcessing
@@ -24,6 +26,10 @@ import androidx.core.content.FileProvider
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import com.ryanheise.audioservice.AudioServiceActivity
+import com.hchen.superlyricapi.SuperLyricHelper
+import com.hchen.superlyricapi.SuperLyricData
+import com.hchen.superlyricapi.SuperLyricLine
+import com.hchen.superlyricapi.SuperLyricWord
 import java.io.File
 
 class MainActivity : AudioServiceActivity() {
@@ -31,6 +37,8 @@ class MainActivity : AudioServiceActivity() {
     private var downloadReceiverRegistered = false
     private var lyricsStateReceiverRegistered = false
     private var desktopLyricsChannel: MethodChannel? = null
+    private var superLyricChannel: MethodChannel? = null
+    private var superLyricRegistered = false
     private var bassBoost: BassBoost? = null
     private var bassBoostSessionId: Int? = null
     private var equalizer: Equalizer? = null
@@ -41,6 +49,8 @@ class MainActivity : AudioServiceActivity() {
 
     companion object {
         private const val REQUEST_READ_AUDIO = 1001
+        private const val TAG_SUPER_LYRIC = "SuperLyricPublisher"
+        private const val TAG_BLUETOOTH_LYRICS = "BluetoothLyrics"
     }
 
     private val downloadReceiver = object : BroadcastReceiver() {
@@ -325,8 +335,11 @@ class MainActivity : AudioServiceActivity() {
                         val opacity = call.argument<Double>("opacity")?.toFloat() ?: 0.8f
                         val locked = call.argument<Boolean>("locked") ?: false
                         val passthrough = call.argument<Boolean>("passthrough") ?: false
-                        val textColorLong = call.argument<Long>("textColor") ?: 0xFFFFFFFF
-                        val backgroundColorLong = call.argument<Long>("backgroundColor") ?: 0xFF1A1A2E
+                        // 颜色值小于 2^31 时经 MethodChannel 到达为 Integer，需经 Number 转换
+                        val textColorLong =
+                            (call.argument<Number>("textColor"))?.toLong() ?: 0xFFFFFFFFL
+                        val backgroundColorLong =
+                            (call.argument<Number>("backgroundColor"))?.toLong() ?: 0xFF1A1A2EL
                         val fontSize = call.argument<Double>("fontSize")?.toFloat() ?: 16f
                         val intent = Intent(this, LyricsOverlayService::class.java).apply {
                             action = LyricsOverlayService.ACTION_UPDATE_SETTINGS
@@ -352,6 +365,277 @@ class MainActivity : AudioServiceActivity() {
                     else -> result.notImplemented()
                 }
             }
+
+        // SuperLyricApi 歌词发布到系统服务
+        superLyricChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "kgka_music_hl/super_lyric"
+        )
+        superLyricChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "isAvailable" -> {
+                    runCatching {
+                        SuperLyricHelper.isAvailable()
+                    }.onSuccess { available ->
+                        result.success(available)
+                    }.onFailure { error ->
+                        Log.w(TAG_SUPER_LYRIC, "isAvailable failed: ${error.message}")
+                        result.success(false)
+                    }
+                }
+                "registerPublisher" -> {
+                    runCatching {
+                        if (!superLyricRegistered) {
+                            SuperLyricHelper.registerPublisher()
+                            superLyricRegistered = true
+                        }
+                        // 以系统服务里的真实注册状态为准（本地标志位可能过期）
+                        val registered = runCatching {
+                            SuperLyricHelper.isPublisherRegistered()
+                        }.getOrNull() ?: superLyricRegistered
+                        Log.d(TAG_SUPER_LYRIC, "registerPublisher: registered=$registered")
+                        result.success(registered)
+                    }.onFailure { error ->
+                        Log.w(TAG_SUPER_LYRIC, "registerPublisher failed: ${error.message}")
+                        result.success(false)
+                    }
+                }
+                "unregisterPublisher" -> {
+                    runCatching {
+                        if (superLyricRegistered) {
+                            SuperLyricHelper.unregisterPublisher()
+                            superLyricRegistered = false
+                        }
+                        result.success(null)
+                    }.onFailure {
+                        result.success(null)
+                    }
+                }
+                "sendLyric" -> {
+                    runCatching {
+                        // 自愈：启动时注册可能因系统服务未就绪而失败，
+                        // 这里在首次发送前补注册一次（幂等，服务端按 UID 去重）
+                        if (!superLyricRegistered) {
+                            SuperLyricHelper.registerPublisher()
+                            superLyricRegistered = true
+                        }
+                        val title = call.argument<String>("title") ?: ""
+                        val artist = call.argument<String>("artist") ?: ""
+                        val album = call.argument<String>("album") ?: ""
+                        val lyricText = call.argument<String>("lyricText") ?: ""
+                        // ⚠️ Dart int 经 MethodChannel 传输后，能放进 32 位时是 Integer，
+                        // 直接 cast Long 会抛 ClassCastException，必须经 Number.toLong() 转换
+                        val lyricStartTime =
+                            (call.argument<Number>("lyricStartTime"))?.toLong() ?: 0L
+                        val lyricEndTime =
+                            (call.argument<Number>("lyricEndTime"))?.toLong() ?: 0L
+                        val secondaryText = call.argument<String>("secondaryText")
+                        val translationText = call.argument<String>("translationText")
+                        val words = call.argument<List<Map<String, Any>>>("words")
+
+                        val lyricData = SuperLyricData()
+                            .setTitle(title)
+                            .setArtist(artist)
+                            .setAlbum(album)
+
+                        // 主歌词行（含逐字）
+                        val lyricWords: Array<SuperLyricWord>? = words?.mapNotNull { w ->
+                            val wordText = w["word"] as? String
+                            val wordStart = (w["startTime"] as? Number)?.toLong()
+                            val wordEnd = (w["endTime"] as? Number)?.toLong()
+                            if (wordText != null && wordStart != null && wordEnd != null) {
+                                SuperLyricWord(wordText, wordStart, wordEnd)
+                            } else null
+                        }?.takeIf { it.isNotEmpty() }?.toTypedArray()
+
+                        val mainLyric = if (lyricWords != null) {
+                            SuperLyricLine(lyricText, lyricWords, lyricStartTime, lyricEndTime)
+                        } else {
+                            SuperLyricLine(lyricText, lyricStartTime, lyricEndTime)
+                        }
+                        lyricData.setLyric(mainLyric)
+
+                        // 副歌词行（音译/罗马音）
+                        if (!secondaryText.isNullOrBlank()) {
+                            lyricData.setSecondary(
+                                SuperLyricLine(secondaryText, lyricStartTime, lyricEndTime)
+                            )
+                        }
+                        // 翻译行
+                        if (!translationText.isNullOrBlank()) {
+                            lyricData.setTranslation(
+                                SuperLyricLine(translationText, lyricStartTime, lyricEndTime)
+                            )
+                        }
+                        SuperLyricHelper.sendLyric(lyricData)
+                        Log.d(
+                            TAG_SUPER_LYRIC,
+                            "sendLyric ok: \"$lyricText\" ($lyricStartTime-$lyricEndTime ms), " +
+                                "words=${lyricWords?.size ?: 0}, " +
+                                "secondary=${!secondaryText.isNullOrBlank()}, " +
+                                "translation=${!translationText.isNullOrBlank()}"
+                        )
+                        result.success(true)
+                    }.onFailure { error ->
+                        Log.w(TAG_SUPER_LYRIC, "sendLyric failed: ${error.message}")
+                        result.error("send_lyric_failed", error.message, null)
+                    }
+                }
+                "sendStop" -> {
+                    runCatching {
+                        if (!superLyricRegistered) {
+                            SuperLyricHelper.registerPublisher()
+                            superLyricRegistered = true
+                        }
+                        SuperLyricHelper.sendStop(SuperLyricData())
+                        Log.d(TAG_SUPER_LYRIC, "sendStop ok")
+                        result.success(true)
+                    }.onFailure { error ->
+                        Log.w(TAG_SUPER_LYRIC, "sendStop failed: ${error.message}")
+                        result.error("send_stop_failed", error.message, null)
+                    }
+                }
+                "debugState" -> {
+                    result.success(
+                        mapOf(
+                            "serviceAvailable" to
+                                (runCatching { SuperLyricHelper.isAvailable() }.getOrNull() ?: false),
+                            "localRegisteredFlag" to superLyricRegistered,
+                            "publisherRegistered" to
+                                (runCatching { SuperLyricHelper.isPublisherRegistered() }
+                                    .getOrNull() ?: false),
+                        )
+                    )
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // 车载蓝牙歌词广播
+        val btLyricChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "kgka_music_hl/bluetooth_lyrics"
+        )
+        btLyricChannel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "broadcastMetaChanged" -> {
+                    runCatching {
+                        val title = call.argument<String>("title") ?: ""
+                        val artist = call.argument<String>("artist") ?: ""
+                        val album = call.argument<String>("album") ?: ""
+                        val lyric = call.argument<String>("lyric") ?: ""
+                        val positionMs = (call.argument<Number>("positionMs") ?: 0).toLong()
+                        val durationMs = (call.argument<Number>("durationMs") ?: 0).toLong()
+                        val playing = call.argument<Boolean>("playing") ?: false
+                        val track = (call.argument<Number>("track") ?: 0).toInt()
+                        val listSize = (call.argument<Number>("listSize") ?: 0).toInt()
+
+                        val extras = Bundle().apply {
+                            putString("track", title)
+                            putString("artist", artist)
+                            putString("album", album)
+                            putString("id", "")
+                            putLong("position", positionMs)
+                            putLong("duration", durationMs)
+                            putBoolean("playing", playing)
+                            putInt("ListSize", listSize)
+                            putInt("trackPos", track)
+                            putString("lyric", lyric)
+                            // 网易云/部分车机额外字段
+                            putString("currentLyric", lyric)
+                            putString("DISPLAY_NAME", title)
+                        }
+
+                        // 标准 Android 音乐元数据变化广播
+                        sendOrderedBroadcast(Intent("com.android.music.metachanged").apply {
+                            putExtras(extras)
+                            setPackage(null)
+                        }, null)
+
+                        // 兼容不同车机/第三方 App 的常见 action
+                        listOf(
+                            "com.android.music.playbackcomplete",
+                            "com.android.music.queuechanged",
+                            "com.android.music.playstatechanged",
+                        ).forEach { action ->
+                            sendBroadcast(Intent(action).apply {
+                                putExtras(Bundle(extras))
+                                setPackage(null)
+                            })
+                        }
+
+                        // QQMusic / Netease 自定义广播（很多车机 App 监听）
+                        sendBroadcast(Intent("com.netease.cloudmusic.metachanged").apply {
+                            putExtras(Bundle(extras))
+                            setPackage(null)
+                        })
+                        sendBroadcast(Intent("com.tencent.qqmusic.metachanged").apply {
+                            putExtras(Bundle(extras))
+                            setPackage(null)
+                        })
+                        // KuGou/KuWo 广播
+                        sendBroadcast(Intent("com.kugou.android.metachanged").apply {
+                            putExtras(Bundle(extras))
+                            setPackage(null)
+                        })
+                        sendBroadcast(Intent("cn.kuwo.player.metachanged").apply {
+                            putExtras(Bundle(extras))
+                            setPackage(null)
+                        })
+
+                        Log.d(
+                            TAG_BLUETOOTH_LYRICS,
+                            "metaChanged ok: \"$title\"/\"$artist\", lyric=\"${lyric.take(24)}\", " +
+                                "pos=${positionMs}ms, playing=$playing, track=$track/$listSize, 7 actions sent"
+                        )
+                        result.success(true)
+                    }.onFailure { error ->
+                        Log.w(TAG_BLUETOOTH_LYRICS, "broadcastMetaChanged failed: ${error.message}")
+                        result.success(false)
+                    }
+                }
+                "broadcastPlayStateChanged" -> {
+                    runCatching {
+                        val title = call.argument<String>("title") ?: ""
+                        val artist = call.argument<String>("artist") ?: ""
+                        val album = call.argument<String>("album") ?: ""
+                        val positionMs = (call.argument<Number>("positionMs") ?: 0).toLong()
+                        val durationMs = (call.argument<Number>("durationMs") ?: 0).toLong()
+                        val playing = call.argument<Boolean>("playing") ?: false
+
+                        val extras = Bundle().apply {
+                            putString("track", title)
+                            putString("artist", artist)
+                            putString("album", album)
+                            putLong("position", positionMs)
+                            putLong("duration", durationMs)
+                            putBoolean("playing", playing)
+                        }
+                        sendBroadcast(Intent("com.android.music.playstatechanged").apply {
+                            putExtras(extras)
+                            setPackage(null)
+                        })
+                        sendBroadcast(Intent("com.netease.cloudmusic.playstatechanged").apply {
+                            putExtras(Bundle(extras))
+                            setPackage(null)
+                        })
+                        sendBroadcast(Intent("com.tencent.qqmusic.playstatechanged").apply {
+                            putExtras(extras)
+                            setPackage(null)
+                        })
+                        Log.d(
+                            TAG_BLUETOOTH_LYRICS,
+                            "playStateChanged ok: \"$title\", playing=$playing, pos=${positionMs}ms"
+                        )
+                        result.success(true)
+                    }.onFailure { error ->
+                        Log.w(TAG_BLUETOOTH_LYRICS, "broadcastPlayStateChanged failed: ${error.message}")
+                        result.success(false)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
     }
 
     private fun readAudioPermission(): String {
@@ -780,6 +1064,10 @@ class MainActivity : AudioServiceActivity() {
     override fun onDestroy() {
         releaseEqualizer()
         releaseBassBoost()
+        if (superLyricRegistered) {
+            runCatching { SuperLyricHelper.unregisterPublisher() }
+            superLyricRegistered = false
+        }
         if (downloadReceiverRegistered) {
             unregisterReceiver(downloadReceiver)
             downloadReceiverRegistered = false

--- a/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/hoilai/mm/music/MainActivity.kt
@@ -552,17 +552,12 @@ class MainActivity : AudioServiceActivity() {
                             setPackage(null)
                         }, null)
 
-                        // 兼容不同车机/第三方 App 的常见 action
-                        listOf(
-                            "com.android.music.playbackcomplete",
-                            "com.android.music.queuechanged",
-                            "com.android.music.playstatechanged",
-                        ).forEach { action ->
-                            sendBroadcast(Intent(action).apply {
-                                putExtras(Bundle(extras))
-                                setPackage(null)
-                            })
-                        }
+                        // 注意：per-line 元数据广播只发 metachanged 系。
+                        // 严禁在此发送 playbackcomplete / queuechanged /
+                        // playstatechanged——这些是"播放完成/队列变化/状态切换"
+                        // 语义信号，随歌词逐句误发会导致车机、仪表盘误判切歌
+                        // 或清空状态；真实状态变化由 broadcastPlayStateChanged
+                        // 专用通道发送。
 
                         // QQMusic / Netease 自定义广播（很多车机 App 监听）
                         sendBroadcast(Intent("com.netease.cloudmusic.metachanged").apply {
@@ -586,7 +581,7 @@ class MainActivity : AudioServiceActivity() {
                         Log.d(
                             TAG_BLUETOOTH_LYRICS,
                             "metaChanged ok: \"$title\"/\"$artist\", lyric=\"${lyric.take(24)}\", " +
-                                "pos=${positionMs}ms, playing=$playing, track=$track/$listSize, 7 actions sent"
+                                "pos=${positionMs}ms, playing=$playing, track=$track/$listSize, 5 actions sent"
                         )
                         result.success(true)
                     }.onFailure { error ->

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,15 +1,27 @@
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 val newBuildDir: Directory =
     rootProject.layout.buildDirectory
         .dir("../../build")
         .get()
 rootProject.layout.buildDirectory.value(newBuildDir)
+
+// ⚠️ 项目级仓库必须在这里声明完整集合。
+// Gradle 的 dependencyResolutionManagement 三种模式都不会"合并"settings 与
+// project 两级仓库（PREFER_SETTINGS 会忽略 project 仓、PREFER_PROJECT 会忽略
+// settings 仓），而 Flutter 插件又必须在 project 级注入本地 engine 产物仓
+// （提供 io.flutter:flutter_embedding_release）。因此唯一同时满足两者的方案：
+// 使用 PREFER_PROJECT（见 settings.gradle.kts），并在这里把所有需要的远程仓库
+// 声明到项目级，与 Flutter 注入的 engine 仓共存。
+//  - google/mavenCentral：AndroidX、Kotlin 等常规依赖
+//  - jitpack.io（主站 + www 镜像）：SuperLyricApi (com.github.HChenX:SuperLyricApi:3.4)
+//    注意 JitPack 首次请求是懒构建（可能 404 后等 60~120s），workflow 已做自动重试。
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+        maven { url = uri("https://www.jitpack.io") }
+    }
+}
 
 subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -8,3 +8,15 @@ android.newDsl=false
 # 无法计算跨盘符相对路径，导致关闭缓存时抛出 IllegalArgumentException。
 # 禁用增量编译可消除这些构建警告，对产物没有影响，仅轻微增加编译时间。
 kotlin.incremental=false
+
+# ===== Gradle HTTP / 依赖解析稳健性（CI 环境网络抖动 & JitPack 冷启动） =====
+# 连接/读写超时 120s（默认只有 10s，GitHub Actions 访问海外仓库经常超时）
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000
+# 依赖仓库重试策略：最多重试 5 次，总等待上限 180 秒
+org.gradle.internal.resolve.retry.timeout=180
+systemProp.http.keepAlive=true
+systemProp.http.maxConnections=20
+# 并行构建 + 缓存（加快 Gradle 配置 & 编译速度）
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -15,10 +15,95 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+
+    // 显式把 plugins {} block 中声明的 plugin id 映射到真实的 Maven artifact
+    // 坐标，避免 Gradle 去 Google Maven 查找 plugin marker（例如
+    // com.android.application.gradle.plugin:8.6.1.pom）。因为 marker 并非
+    // 所有 AGP 版本都有上传，在 CI 环境经常出现 "plugin ... was not found"。
+    resolutionStrategy {
+        eachPlugin {
+            when (requested.id.id) {
+                "com.android.application",
+                "com.android.library",
+                "com.android.dynamic-feature",
+                "com.android.test",
+                "com.android.instantapp" -> {
+                    // ⚠️ 版本号 MUST_SYNC：请与文件底部 plugins {} block 中
+                    //   `id("com.android.application") version "x.y.z"` 保持一致！
+                    // 为什么硬编码而不写顶层 const val？
+                    //   - Gradle 会在脚本主体编译 "之前" 对 `plugins {}` block 做
+                    //     一次单独的静态解析/抽取；顶层 const val 在那个阶段
+                    //     根本不存在，会直接导致
+                    //     `Unresolved reference: AGP_VERSION` 脚本编译失败。
+                    // 为什么要有兜底？
+                    //   - Flutter includeBuild + 根 build.gradle.kts 里
+                    //     `subprojects { evaluationDependsOn(":app") }` 会走一条合成
+                    //     的 plugin-apply 路径，此时 requested.version == null，
+                    //     不能再 error()。
+                    // ⚠️ 版本不能低于 Flutter stable 要求的最低 AGP（当前 CI 上
+                    //   是 8.11.1），否则 flutter-gradle-plugin apply 时直接报错：
+                    //   "Your project's Android Gradle Plugin version (x.y.z) is
+                    //    lower than Flutter's minimum supported version 8.11.1"。
+                    val agpVersion = requested.version ?: "8.11.1"
+                    useModule("com.android.tools.build:gradle:$agpVersion")
+                }
+                "org.jetbrains.kotlin.android",
+                "kotlin-android",
+                "android",
+                "org.jetbrains.kotlin.jvm",
+                "kotlin",
+                "jvm" -> {
+                    // ⚠️ MUST_SYNC：请与 `plugins {}` block 中
+                    //   `id("org.jetbrains.kotlin.android") version "x.y.z"` 保持一致。
+                    // 2.2.20 是项目原始版本（本地已验证可用），不要随意降级。
+                    val kotlinVersion = requested.version ?: "2.2.20"
+                    useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+                }
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    // ⚠️ 对 Flutter 项目必须使用 PREFER_PROJECT（三种模式实测结论）：
+    // - FAIL_ON_PROJECT_REPOS：配置期直接报错退出——Flutter 官方插件
+    //   `dev.flutter.flutter-gradle-plugin` 在 apply 时会向各 project 动态注入
+    //   maven 仓库，触发 "repository 'maven' was added by plugin ..."。
+    // - PREFER_SETTINGS：配置期能过，但 Flutter 注入的本地 engine 产物仓
+    //   （bin/cache/artifacts/engine/...，唯一提供 io.flutter:flutter_embedding_release
+    //   的仓库）会被静默忽略 → 执行期报：
+    //   "Could not find io.flutter:flutter_embedding_release:1.0.0-<hash>"
+    // - PREFER_PROJECT（正确）：project 仓（含 Flutter engine 仓）优先参与解析，
+    //   settings 仓（google/mavenCentral/JitPack 双镜像）作为兜底继续生效，
+    //   SuperLyricApi 等 JitPack 依赖依然能解析。
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
+    repositories {
+        google()
+        mavenCentral()
+        // JitPack（主站 + 官方镜像，按顺序尝试）——用于 SuperLyricApi:3.4
+        // 注意：JitPack 是首次请求时才在服务器端"懒构建"对应 GitHub tag/commit，
+        // 第一次解析可能返回 404，等 60~120 秒后再请求即可拉到构建产物，
+        // workflow 里对这种情况做了一次自动 sleep + refresh-dependencies 重试。
+        maven { url = uri("https://jitpack.io") }
+        maven { url = uri("https://www.jitpack.io") }
+    }
 }
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    // Android Gradle Plugin 与 Kotlin 版本说明：
+    // - AGP 8.11.1 是 CI 上 Flutter stable（subosito/flutter-action@v2 拉取的最新版）
+    //   要求的最低 AGP 版本，低于它 flutter-gradle-plugin apply 时会直接报错：
+    //   "Your project's AGP version is lower than Flutter's minimum supported
+    //    version of Android Gradle Plugin version 8.11.1"。
+    //   （历史教训：曾为规避 marker 解析把 AGP 降到 8.6.1/8.7.4，
+    //    结果触发上述校验失败；真正解决 marker 问题的是上面
+    //    resolutionStrategy.eachPlugin 的 useModule 显式映射。）
+    // - AGP 9+ 才开始只读 new DSL；本项目在 gradle.properties 已配置
+    //   `android.newDsl=false` 提前 opt-out，保持 Flutter 兼容。
+    // - Kotlin 2.2.20 是项目原始版本（本地已验证），与 AGP 8.11.1 + Gradle 8.14 配合正常。
+    // ⚠️ MUST_SYNC：上面 pluginManagement.resolutionStrategy.eachPlugin 里的
+    //   fallback 硬编码 ("8.11.1" / "2.2.20") 必须与以下两行的 version 保持一致。
     id("com.android.application") version "8.11.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }

--- a/lib/controllers/player_controller.dart
+++ b/lib/controllers/player_controller.dart
@@ -1302,9 +1302,11 @@ class PlayerController extends ChangeNotifier {
 
   int _lastDesktopLyricIndex = -1;
   int _lastSuperLyricIndex = -1;
-  bool _lastSuperLyricPlaying = true;
+  // 初始为 false：App 启动时通常处于暂停态，若初始为 true，
+  // 首个 position tick 就会向系统发送一次无意义的 stop/playstate 广播。
+  bool _lastSuperLyricPlaying = false;
   int _lastBluetoothLyricIndex = -1;
-  bool _lastBluetoothPlaying = true;
+  bool _lastBluetoothPlaying = false;
 
   void _maybeSyncDesktopLyricFromPosition() {
     if (!_shouldShowDesktopLyrics || lyrics.isEmpty) return;

--- a/lib/controllers/player_controller.dart
+++ b/lib/controllers/player_controller.dart
@@ -1385,6 +1385,8 @@ class PlayerController extends ChangeNotifier {
     if (!bluetoothLyricsEnabled || currentSong == null) return;
     final song = currentSong!;
     final resolvedIndex = index ?? (lyrics.isEmpty ? -1 : activeLyricIndex);
+    // 行变化判定基准快照（下方 if/else 会更新 _lastBluetoothLyricIndex）
+    final prevIndex = _lastBluetoothLyricIndex;
 
     final String lyricText;
     final String? translationText;
@@ -1413,7 +1415,10 @@ class PlayerController extends ChangeNotifier {
     );
 
     // 2. 系统广播 + 各 App 自定义广播
-    final lineChanged = force || resolvedIndex != index || lyricText.isNotEmpty;
+    // 行变化判定必须用快照对比：不能用恒真的 lyricText.isNotEmpty，
+    // 否则 lineChanged 恒真、forcePlayState 分支永远无法执行，
+    // 播放/暂停状态广播会被静默吞掉。
+    final lineChanged = force || prevIndex != _lastBluetoothLyricIndex;
     if (lineChanged) {
       unawaited(
         _bluetoothLyrics.broadcastMetaChanged(
@@ -1428,7 +1433,9 @@ class PlayerController extends ChangeNotifier {
           listSize: queue.length,
         ),
       );
-    } else if (forcePlayState) {
+    }
+    // 播放/暂停状态变化独立发送，不依赖行是否变化。
+    if (forcePlayState) {
       unawaited(
         _bluetoothLyrics.broadcastPlayStateChanged(
           title: song.title,

--- a/lib/controllers/player_controller.dart
+++ b/lib/controllers/player_controller.dart
@@ -16,8 +16,10 @@ import '../services/cache_service.dart';
 import '../services/desktop_lyrics_service.dart';
 import '../services/music_api.dart';
 import '../services/music_audio_handler.dart';
+import '../services/bluetooth_lyrics_service.dart';
 import '../services/playback_history_service.dart';
 import '../services/playback_stats_service.dart';
+import '../services/super_lyric_service.dart';
 import 'download_controller.dart';
 import 'local_music_controller.dart';
 
@@ -52,6 +54,8 @@ class PlayerController extends ChangeNotifier {
       'settings.auto_play_on_device_connected';
   static const _volumeNormalizationEnabledSettingKey =
       'settings.volume_normalization_enabled';
+  static const _bluetoothLyricsEnabledSettingKey =
+      'settings.bluetooth_lyrics_enabled';
   static const _queueKey = 'playback.queue';
   static const _currentSongKey = 'playback.current_song';
   static const _currentPositionKey = 'playback.current_position';
@@ -100,6 +104,7 @@ class PlayerController extends ChangeNotifier {
 
   PlayerController(this._api, this._audioHandler) {
     unawaited(_restoreSettings());
+    unawaited(_superLyric.registerPublisher());
     _audioHandler.attachTransportControls(onNext: next, onPrevious: previous);
     _desktopLyrics.setVisibilityChangedHandler(_handleDesktopLyricsVisibility);
     _positionSub = audioPlayer.positionStream.listen((value) {
@@ -109,6 +114,8 @@ class PlayerController extends ChangeNotifier {
       _maybeCompleteFromPosition(value);
       _maybeStopClimaxPreview(value);
       _maybeSyncDesktopLyricFromPosition();
+      _syncSuperLyricFromPosition();
+      _syncBluetoothLyricsFromPosition();
       notifyListeners();
     });
     // Send timing anchors; Android animates karaoke progress at display refresh.
@@ -163,6 +170,8 @@ class PlayerController extends ChangeNotifier {
   final DesktopLyricsService _desktopLyrics = DesktopLyricsService();
   final PlaybackHistoryService _historyService = PlaybackHistoryService();
   final PlaybackStatsService _statsService = PlaybackStatsService();
+  final SuperLyricService _superLyric = SuperLyricService();
+  final BluetoothLyricsService _bluetoothLyrics = BluetoothLyricsService();
 
   AudioPlayer get audioPlayer => _audioHandler.audioPlayer;
 
@@ -231,6 +240,7 @@ class PlayerController extends ChangeNotifier {
   bool autoResumeAfterInterruption = false;
   bool autoPlayOnDeviceConnected = false;
   bool volumeNormalizationEnabled = false;
+  bool bluetoothLyricsEnabled = false;
   bool desktopLyricsEnabled = false;
   DesktopLyricsSettings desktopLyricsSettings = const DesktopLyricsSettings();
   Timer? _autoResumeTimer;
@@ -364,6 +374,10 @@ class PlayerController extends ChangeNotifier {
     }
     lyrics = const [];
     _lastDesktopLyricIndex = -1;
+    _lastSuperLyricIndex = -1;
+    _lastSuperLyricPlaying = true;
+    _lastBluetoothLyricIndex = -1;
+    _lastBluetoothPlaying = true;
     _saveQueueState();
     _startPositionSaving();
     notifyListeners();
@@ -590,6 +604,38 @@ class PlayerController extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_volumeNormalizationEnabledSettingKey, enabled);
     await _applyVolumeNormalization();
+    notifyListeners();
+  }
+
+  /// 车载蓝牙歌词功能是否受支持（仅 Android）。
+  bool get isBluetoothLyricsSupported => BluetoothLyricsService.isSupportedPlatform;
+
+  /// 开关车载蓝牙歌词功能。
+  Future<void> setBluetoothLyricsEnabled(bool enabled) async {
+    if (bluetoothLyricsEnabled == enabled) return;
+    bluetoothLyricsEnabled = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_bluetoothLyricsEnabledSettingKey, enabled);
+    // 关闭时，清理残留广播
+    if (!enabled && currentSong != null) {
+      unawaited(
+        _bluetoothLyrics.broadcastMetaChanged(
+          title: currentSong!.title,
+          artist: currentSong!.artist,
+          album: currentSong!.albumName,
+          lyric: '',
+          position: position,
+          duration: currentSong!.duration ?? Duration.zero,
+          playing: isPlaying,
+          trackIndex: currentIndex,
+          listSize: queue.length,
+        ),
+      );
+      _audioHandler.updateLyricMetadata(lyricText: null);
+    } else if (enabled) {
+      // 打开时立即推送一次当前状态
+      _pushBluetoothLyricForCurrentLine(force: true);
+    }
     notifyListeners();
   }
 
@@ -1255,6 +1301,10 @@ class PlayerController extends ChangeNotifier {
   }
 
   int _lastDesktopLyricIndex = -1;
+  int _lastSuperLyricIndex = -1;
+  bool _lastSuperLyricPlaying = true;
+  int _lastBluetoothLyricIndex = -1;
+  bool _lastBluetoothPlaying = true;
 
   void _maybeSyncDesktopLyricFromPosition() {
     if (!_shouldShowDesktopLyrics || lyrics.isEmpty) return;
@@ -1265,6 +1315,131 @@ class PlayerController extends ChangeNotifier {
     }
     // Karaoke progress for current line
     _syncDesktopKaraokeProgress();
+  }
+
+  void _syncSuperLyricFromPosition() {
+    if (currentSong == null) return;
+    if (lyrics.isEmpty) {
+      // 无歌词时仅处理播放状态变化
+      if (!isPlaying && _lastSuperLyricPlaying) {
+        _lastSuperLyricPlaying = false;
+        _lastSuperLyricIndex = -1;
+        unawaited(_superLyric.sendStop());
+      } else if (isPlaying && !_lastSuperLyricPlaying) {
+        _lastSuperLyricPlaying = true;
+      }
+      return;
+    }
+    final index = activeLyricIndex;
+    // 行变化且正在播放 → 发歌词
+    final lineChanged = isPlaying && (index != _lastSuperLyricIndex);
+    // 从暂停切到播放 → 重新发送当前行
+    final resumed = isPlaying && !_lastSuperLyricPlaying;
+    if (lineChanged || resumed) {
+      _lastSuperLyricIndex = index;
+      _lastSuperLyricPlaying = true;
+      final clampedIndex = index.clamp(0, lyrics.length - 1);
+      final line = lyrics[clampedIndex];
+      final lineEndTime = line.time +
+          (line.duration ?? _estimatedLineDuration(clampedIndex) ?? Duration.zero);
+      unawaited(
+        _superLyric.sendLyric(
+          song: currentSong!,
+          line: line,
+          lineEndTime: lineEndTime,
+        ),
+      );
+    } else if (!isPlaying && _lastSuperLyricPlaying) {
+      // 切到暂停：发送 stop
+      _lastSuperLyricPlaying = false;
+      unawaited(_superLyric.sendStop());
+    }
+  }
+
+  /// 位置流中的车载蓝牙歌词同步入口。
+  void _syncBluetoothLyricsFromPosition() {
+    if (!bluetoothLyricsEnabled) return;
+    if (currentSong == null) return;
+    final index = lyrics.isEmpty ? -1 : activeLyricIndex;
+    final lineChanged = index != _lastBluetoothLyricIndex;
+    final playingChanged = isPlaying != _lastBluetoothPlaying;
+    // 状态或行变化时推送
+    if (lineChanged || playingChanged) {
+      _pushBluetoothLyricForCurrentLine(
+        index: index,
+        forcePlayState: playingChanged,
+      );
+    }
+  }
+
+  /// 推送当前行歌词到车载蓝牙（MediaSession extras + 系统广播）。
+  ///
+  /// - [force]：忽略行/状态缓存直接发送一次（用于用户刚打开开关时）
+  /// - [index]：当前歌词行索引，-1 表示无歌词；默认取 activeLyricIndex
+  /// - [forcePlayState]：即使行未变也发送 playStateChanged 广播
+  void _pushBluetoothLyricForCurrentLine({
+    bool force = false,
+    int? index,
+    bool forcePlayState = false,
+  }) {
+    if (!bluetoothLyricsEnabled || currentSong == null) return;
+    final song = currentSong!;
+    final resolvedIndex = index ?? (lyrics.isEmpty ? -1 : activeLyricIndex);
+
+    final String lyricText;
+    final String? translationText;
+    final String? romanizationText;
+    if (lyrics.isEmpty || resolvedIndex < 0) {
+      lyricText = '';
+      translationText = null;
+      romanizationText = null;
+      _lastBluetoothLyricIndex = -1;
+    } else {
+      final clampedIndex = resolvedIndex.clamp(0, lyrics.length - 1);
+      final line = lyrics[clampedIndex];
+      lyricText = line.text;
+      translationText = line.translation;
+      romanizationText = line.romanization;
+      _lastBluetoothLyricIndex = clampedIndex;
+    }
+
+    _lastBluetoothPlaying = isPlaying;
+
+    // 1. MediaSession extras 歌词字段（部分 App/Xposed 读取 MediaSession）
+    _audioHandler.updateLyricMetadata(
+      lyricText: lyricText.isEmpty ? null : lyricText,
+      translationText: translationText,
+      romanizationText: romanizationText,
+    );
+
+    // 2. 系统广播 + 各 App 自定义广播
+    final lineChanged = force || resolvedIndex != index || lyricText.isNotEmpty;
+    if (lineChanged) {
+      unawaited(
+        _bluetoothLyrics.broadcastMetaChanged(
+          title: song.title,
+          artist: song.artist,
+          album: song.albumName,
+          lyric: lyricText,
+          position: position,
+          duration: song.duration ?? Duration.zero,
+          playing: isPlaying,
+          trackIndex: currentIndex,
+          listSize: queue.length,
+        ),
+      );
+    } else if (forcePlayState) {
+      unawaited(
+        _bluetoothLyrics.broadcastPlayStateChanged(
+          title: song.title,
+          artist: song.artist,
+          album: song.albumName,
+          position: position,
+          duration: song.duration ?? Duration.zero,
+          playing: isPlaying,
+        ),
+      );
+    }
   }
 
   void _syncDesktopKaraokeProgress() {
@@ -1493,6 +1668,9 @@ class PlayerController extends ChangeNotifier {
     volumeNormalizationEnabled =
         prefs.getBool(_volumeNormalizationEnabledSettingKey) ??
         volumeNormalizationEnabled;
+    bluetoothLyricsEnabled =
+        prefs.getBool(_bluetoothLyricsEnabledSettingKey) ??
+            bluetoothLyricsEnabled;
     playbackSpeed = prefs.getDouble(_playbackSpeedSettingKey) ?? playbackSpeed;
     desktopLyricsEnabled =
         prefs.getBool(_desktopLyricsEnabledSettingKey) ?? desktopLyricsEnabled;

--- a/lib/services/bluetooth_lyrics_service.dart
+++ b/lib/services/bluetooth_lyrics_service.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// 车载蓝牙歌词服务。
+///
+/// 作用：
+/// 1. 发送标准 Android 音乐广播（`com.android.music.metachanged` 等）并携带 `lyric` 字段，
+///    大多数第三方车机歌词 App / DIY 中控 / Xposed 模块会监听这些广播并在车机屏显示歌词。
+/// 2. 同时发送常见音乐 App（网易云、QQ 音乐、酷狗、酷我）的自定义 action，保证最大兼容性。
+///
+/// 仅在 Android 平台生效，非 Android 平台所有方法均为安全的 no-op。
+class BluetoothLyricsService {
+  static const _channel = MethodChannel('kgka_music_hl/bluetooth_lyrics');
+
+  static bool get isSupportedPlatform {
+    return !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+  }
+
+  /// 发送「歌曲/歌词变化」广播。
+  ///
+  /// 歌词行变化或切歌时调用。
+  Future<void> broadcastMetaChanged({
+    required String title,
+    required String artist,
+    String? album,
+    String? lyric,
+    required Duration position,
+    required Duration duration,
+    required bool playing,
+    required int trackIndex,
+    required int listSize,
+  }) async {
+    if (!isSupportedPlatform) return;
+    try {
+      await _channel.invokeMethod<void>('broadcastMetaChanged', {
+        'title': title,
+        'artist': artist,
+        'album': album ?? '',
+        'lyric': lyric ?? '',
+        'positionMs': position.inMilliseconds,
+        'durationMs': duration.inMilliseconds,
+        'playing': playing,
+        'track': trackIndex,
+        'listSize': listSize,
+      });
+    } on MissingPluginException {
+      // ignore
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  /// 发送「播放状态变化」广播（暂停/恢复/停止）。
+  Future<void> broadcastPlayStateChanged({
+    required String title,
+    required String artist,
+    String? album,
+    required Duration position,
+    required Duration duration,
+    required bool playing,
+  }) async {
+    if (!isSupportedPlatform) return;
+    try {
+      await _channel.invokeMethod<void>('broadcastPlayStateChanged', {
+        'title': title,
+        'artist': artist,
+        'album': album ?? '',
+        'positionMs': position.inMilliseconds,
+        'durationMs': duration.inMilliseconds,
+        'playing': playing,
+      });
+    } on MissingPluginException {
+      // ignore
+    } catch (_) {
+      // ignore
+    }
+  }
+}

--- a/lib/services/music_audio_handler.dart
+++ b/lib/services/music_audio_handler.dart
@@ -16,6 +16,7 @@ class MusicAudioHandler extends BaseAudioHandler
   Future<void> Function()? _onNext;
   Future<void> Function()? _onPrevious;
   int _queueIndex = 0;
+  Song? _currentSong;
 
   void attachTransportControls({
     required Future<void> Function() onNext,
@@ -36,6 +37,7 @@ class MusicAudioHandler extends BaseAudioHandler
     required List<Song> queueSongs,
     required int queueIndex,
   }) async {
+    _currentSong = song;
     _queueIndex = queueIndex < 0 ? 0 : queueIndex;
     final currentItem = _mediaItemFor(song);
     final items = queueSongs.map(_mediaItemFor).toList(growable: false);
@@ -61,11 +63,46 @@ class MusicAudioHandler extends BaseAudioHandler
     required int queueIndex,
     Song? currentSong,
   }) async {
+    if (currentSong != null) _currentSong = currentSong;
     _queueIndex = queueIndex < 0 ? 0 : queueIndex;
     queue.add(queueSongs.map(_mediaItemFor).toList(growable: false));
     if (currentSong != null) {
       mediaItem.add(_mediaItemFor(currentSong));
     }
+  }
+
+  /// 更新当前播放歌曲的 MediaSession Metadata，写入歌词字段。
+  ///
+  /// 大多数车机系统不会直接读 AVRCP 里的歌词，但通过 media_item extras
+  /// 写入 `lyric / currentLyric` 字段后，SuperLyric 模块或第三方车载 App 可从
+  /// MediaSession 元数据里取出歌词并展示。
+  ///
+  /// 当 [lyricText] 为 `null` 时表示清空歌词（暂停/切歌前）。
+  void updateLyricMetadata({
+    String? lyricText,
+    String? translationText,
+    String? romanizationText,
+  }) {
+    final song = _currentSong;
+    if (song == null) return;
+    final Map<String, dynamic> extras = {
+      'hash': song.hash,
+      'songId': song.id,
+      if (lyricText != null) 'lyric': lyricText,
+      if (lyricText != null) 'currentLyric': lyricText,
+      if (translationText != null) 'translationLyric': translationText,
+      if (romanizationText != null) 'romanLyric': romanizationText,
+    };
+    final updated = MediaItem(
+      id: song.hash.isEmpty ? song.id : song.hash,
+      album: song.albumName,
+      title: song.title,
+      artist: song.artist,
+      duration: song.duration,
+      artUri: song.coverUrl == null ? null : Uri.tryParse(song.coverUrl!),
+      extras: extras,
+    );
+    mediaItem.add(updated);
   }
 
   @override

--- a/lib/services/super_lyric_service.dart
+++ b/lib/services/super_lyric_service.dart
@@ -97,7 +97,10 @@ class SuperLyricService {
     required LyricLine line,
     Duration? lineEndTime,
   }) async {
-    if (!isSupportedPlatform || !_registered) return;
+    // 只按平台门控；注册状态交给下方自愈块处理。
+    // ⚠️ 不能在这里写 `|| !_registered` 提前返回，否则下方自愈注册
+    // 变成不可达死代码，注册失败过的会话将永远发不出歌词。
+    if (!isSupportedPlatform) return;
     final int endMs;
     if (lineEndTime != null) {
       endMs = lineEndTime.inMilliseconds;

--- a/lib/services/super_lyric_service.dart
+++ b/lib/services/super_lyric_service.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '../models/music_models.dart';
+
+/// SuperLyric 逐字数据，用于卡拉OK风格。
+class SuperLyricWordData {
+  const SuperLyricWordData({
+    required this.word,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  final String word;
+  final Duration startTime;
+  final Duration endTime;
+
+  Map<String, dynamic> toMap() => {
+        'word': word,
+        'startTime': startTime.inMilliseconds,
+        'endTime': endTime.inMilliseconds,
+      };
+}
+
+/// SuperLyric 系统级歌词发布服务。
+///
+/// 通过 Android SuperLyricApi（基于 Binder/AIDL）将实时歌词数据
+/// 发布到系统级服务，供 Xposed 模块等接收方使用。
+///
+/// 仅在 Android 平台生效，非 Android 平台的所有操作均为安全的 no-op。
+class SuperLyricService {
+  static const _channel = MethodChannel('kgka_music_hl/super_lyric');
+
+  bool _registered = false;
+
+  /// 是否为支持的平台（仅 Android）。
+  static bool get isSupportedPlatform {
+    return !kIsWeb && defaultTargetPlatform == TargetPlatform.android;
+  }
+
+  /// 检查 SuperLyric 系统服务是否可用（即 SuperLyric Xposed 模块是否安装并激活）。
+  Future<bool> isAvailable() async {
+    if (!isSupportedPlatform) return false;
+    try {
+      final result = await _channel.invokeMethod<bool>('isAvailable');
+      return result ?? false;
+    } on MissingPluginException {
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// 注册为 SuperLyric 发布者（应用启动时调用一次即可）。
+  ///
+  /// 返回是否注册成功。未安装 SuperLyric 模块时返回 false，不会抛错。
+  /// 失败不会缓存结果——之后每次调用都会重新尝试（启动时系统服务可能未就绪）。
+  Future<bool> registerPublisher() async {
+    if (!isSupportedPlatform) return false;
+    if (_registered) return true;
+    try {
+      final result = await _channel.invokeMethod<bool>('registerPublisher');
+      final ok = result ?? false;
+      _registered = ok;
+      debugPrint('[SuperLyric] registerPublisher -> $ok');
+      return ok;
+    } on MissingPluginException {
+      debugPrint('[SuperLyric] registerPublisher: MissingPluginException');
+      return false;
+    } catch (e) {
+      debugPrint('[SuperLyric] registerPublisher failed: $e');
+      return false;
+    }
+  }
+
+  /// 主动取消注册（应用销毁时通常由系统自动清理）。
+  Future<void> unregisterPublisher() async {
+    if (!isSupportedPlatform || !_registered) return;
+    try {
+      await _channel.invokeMethod<void>('unregisterPublisher');
+      _registered = false;
+    } on MissingPluginException {
+      // ignore
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  /// 发送当前歌词行到系统服务。
+  ///
+  /// - [song] 当前歌曲信息（标题、艺人、专辑等）
+  /// - [line] 当前歌词行（含时间、文本、翻译、罗马音、逐字数据）
+  /// - [lineEndTime] 当前行的预计结束时间，用于计算 SuperLyricLine 的 endTime；
+  ///   不传时使用行内 duration 或退化为行开始时间
+  Future<void> sendLyric({
+    required Song song,
+    required LyricLine line,
+    Duration? lineEndTime,
+  }) async {
+    if (!isSupportedPlatform || !_registered) return;
+    final int endMs;
+    if (lineEndTime != null) {
+      endMs = lineEndTime.inMilliseconds;
+    } else if (line.duration != null) {
+      endMs = line.time.inMilliseconds + line.duration!.inMilliseconds;
+    } else {
+      endMs = line.time.inMilliseconds;
+    }
+
+    final List<Map<String, dynamic>> words;
+    if (line.words.isNotEmpty) {
+      // ⚠️ w.time 已是歌曲时间轴上的绝对时间（解析器已加上行起点+全局偏移，
+      // 见 music_api.dart 的 yrc 解析与 LyricLine.activeWordIndex 的用法），
+      // 不能再叠加 line.time，否则逐字时间约翻倍，接收端整句演唱期间
+      // 判定无激活字（全灰），直到行结束才兜底高亮。
+      words = line.words.map((w) {
+        final start = w.time.inMilliseconds;
+        return SuperLyricWordData(
+          word: w.text,
+          startTime: Duration(milliseconds: start),
+          endTime: Duration(milliseconds: start + w.duration.inMilliseconds),
+        ).toMap();
+      }).toList();
+    } else {
+      words = const [];
+    }
+
+    if (!_registered) {
+      // 自愈：启动时注册可能因系统服务未就绪而失败，这里补注册一次。
+      final ok = await registerPublisher();
+      if (!ok) {
+        debugPrint('[SuperLyric] sendLyric skipped: not registered');
+        return;
+      }
+    }
+
+    try {
+      await _channel.invokeMethod<void>('sendLyric', {
+        'title': song.title,
+        'artist': song.artist,
+        'album': song.albumName ?? '',
+        'lyricText': line.text,
+        'lyricStartTime': line.time.inMilliseconds,
+        'lyricEndTime': endMs,
+        'secondaryText': line.romanization,
+        'translationText': line.translation,
+        'words': words,
+      });
+    } on MissingPluginException {
+      debugPrint('[SuperLyric] sendLyric: MissingPluginException');
+    } catch (e) {
+      // 失败不影响正常播放，但打印日志方便排查
+      debugPrint('[SuperLyric] sendLyric failed: $e');
+    }
+  }
+
+  /// 发送播放停止/暂停事件。
+  Future<void> sendStop() async {
+    if (!isSupportedPlatform) return;
+    if (!_registered) {
+      final ok = await registerPublisher();
+      if (!ok) return;
+    }
+    try {
+      await _channel.invokeMethod<void>('sendStop');
+    } on MissingPluginException {
+      debugPrint('[SuperLyric] sendStop: MissingPluginException');
+    } catch (e) {
+      debugPrint('[SuperLyric] sendStop failed: $e');
+    }
+  }
+
+  /// 诊断信息：系统服务可用性、本地注册标志、系统服务中的真实注册状态。
+  ///
+  /// 用于排查"接收端列表里有本应用但收不到歌词"这类问题。
+  Future<Map<String, dynamic>?> debugState() async {
+    if (!isSupportedPlatform) return null;
+    try {
+      final result =
+          await _channel.invokeMethod<Map<dynamic, dynamic>>('debugState');
+      return result?.cast<String, dynamic>();
+    } catch (e) {
+      debugPrint('[SuperLyric] debugState failed: $e');
+      return null;
+    }
+  }
+}

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -213,6 +213,17 @@ class SettingsPage extends StatelessWidget {
                       value: player.autoPlayOnDeviceConnected,
                       onChanged: player.setAutoPlayOnDeviceConnected,
                     ),
+                    if (player.isBluetoothLyricsSupported) ...[
+                      _SettingsDivider(),
+                      _SettingsSwitchTile(
+                        icon: Icons.directions_car_rounded,
+                        iconColor: colorScheme.primary,
+                        title: '车载蓝牙歌词',
+                        subtitle: '将实时歌词推送到车机或第三方车载歌词 App 显示',
+                        value: player.bluetoothLyricsEnabled,
+                        onChanged: player.setBluetoothLyricsEnabled,
+                      ),
+                    ],
                     _SettingsDivider(),
                     _SettingsSwitchTile(
                       icon: Icons.volume_up_rounded,


### PR DESCRIPTION
作者你好！👋 首先衷心感谢你开发了这款优秀的音乐播放器，代码结构清晰、
体验完整，我一直是它的用户。
在这个基础上，我为它适配了两套「歌词外发」能力，让播放器可以接入目前主流
的系统级歌词方案（**状态栏歌词、超级岛歌词**这类插件，以及车载蓝牙歌词接
收端），希望能有机会并入主分支，让更多用户用上 🙏
## ✨ 功能一：SuperLyric 系统歌词发布（适配超级岛歌词 / 状态栏歌词类插件）
- 通过 [SuperLyricApi](https://github.com/HChenX/SuperLyricApi) （JitPack：
  `com.github.HChenX:SuperLyricApi:3.4`）将实时歌词逐行发布到系统服务；
- 支持逐字卡拉OK时间轴（yrc 逐字数据）、翻译、罗马音副行；暂停自动发送
  停止事件，切歌自动重置行状态；
- 带自愈机制：系统服务未就绪时会在发送前自动补注册；关键链路有 logcat
  日志（tag: `SuperLyricPublisher`）便于排查。
## 🚗 功能二：车载蓝牙歌词广播
- 每行歌词变化时发送标准 Android 音乐广播（`com.android.music.metachanged`
  等），Bundle 携带 `track / artist / album / lyric / currentLyric /
  position / duration / playing / ListSize / trackPos`；
- 同时发送网易云 / QQ 音乐 / 酷狗 / 酷我的自定义 action，最大化兼容第三方
  车机歌词应用；
- 同步更新 MediaSession Metadata extras（`lyric / currentLyric /
  translationLyric / romanLyric`），兼容读取 MediaSession 的接收端；
- 设置页新增「车载蓝牙歌词」开关（仅 Android 显示）。
## 🔧 构建适配
- `settings.gradle.kts`：新增 JitPack 仓库与插件解析策略（`resolutionStrategy`
  显式映射 AGP/Kotlin 插件坐标，规避部分 AGP 版本 plugin marker 未发布的
  问题）；
- `app/build.gradle.kts`：新增 SuperLyricApi 依赖（标记 `isChanging`，规避
  JitPack 懒构建 404 缓存）；`minSdk` 提升至 26（SuperLyricApi 3.4 清单要求）；
  `minifyEnabled` / `shrinkResources` 成对关闭（AGP 要求两者同开同关）；
- 新增 `proguard-rules.pro`：keep SuperLyricApi 类。
## ✅ 测试情况
- 真机实测通过：SuperLyric 接收端可实时收到逐字歌词；车机歌词应用可通过
  metachanged 广播实时显示歌词（已用 logcat 逐行验证两条通道）。
如果有实现细节与你的代码风格或架构规划不一致，或者你希望拆分、调整提交
结构，随时告诉我，我马上改。再次感谢你的辛苦开发！🙏