### PR TITLE
feat: 搜索支持专辑类型

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,78 @@
+name: Build Android APK
+
+# 触发条件：
+#   1. 推送到 master 或 main 分支时自动构建
+#   2. 推送 v* 标签时构建并自动发布 GitHub Release
+#   3. 可在 Actions 页面手动触发 (workflow_dispatch)
+on:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  build-apk:
+    name: Build Android APK (arm64-v8a)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # lib/assets/logo.png 是 Git LFS 跟踪文件，需真实图片用于资源打包
+          lfs: true
+
+      - name: Setup Java (Temurin 17)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Disable Flutter analytics
+        run: flutter config --no-analytics
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      # release 构建：仓库未配置 android/key.properties（已被 .gitignore 忽略），
+      # build.gradle.kts 会自动回退使用 debug 签名，产物可直接安装。
+      # JitPack 的 SuperLyricApi 是"首次请求时才懒构建"，冷启动可能 404 或极慢，
+      # 第一次失败后 sleep 90s 重试一次，让 JitPack 完成远程构建。
+      - name: Build APK (release)
+        run: |
+          flutter build apk --release || {
+            echo "⚠️ 首次构建失败（可能为 JitPack 懒构建中），等待 90s 后重试…"
+            sleep 90
+            flutter build apk --release
+          }
+
+      - name: Upload APK as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kgka-music-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+          retention-days: 30
+
+      - name: Create GitHub Release (on tag push)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: KA Music ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: build/app/outputs/flutter-apk/app-release.apk
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/controllers/player_controller.dart
+++ b/lib/controllers/player_controller.dart
@@ -166,6 +166,15 @@ class PlayerController extends ChangeNotifier {
 
   final MusicApi _api;
   final MusicAudioHandler _audioHandler;
+
+  /// 持久化设置恢复完成信号。
+  ///
+  /// 用于“开机自启播放”等依赖持久化开关值的流程等待设置加载完成，
+  /// 避免在 [_restoreSettings] 完成前把开关误读为默认值。
+  final Completer<void> _settingsRestored = Completer<void>();
+
+  /// 设置（含开机自启开关）从本地恢复完成的 Future。
+  Future<void> get settingsRestored => _settingsRestored.future;
   final AudioEffectsService _audioEffects = AudioEffectsService();
   final DesktopLyricsService _desktopLyrics = DesktopLyricsService();
   final PlaybackHistoryService _historyService = PlaybackHistoryService();
@@ -651,6 +660,15 @@ class PlayerController extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_smartQualitySettingKey, enabled);
     notifyListeners();
+  }
+
+  /// 开机自启播放开关当前是否已开启（从持久化存储读取）。
+  ///
+  /// 供启动流程判断是否需要预加载上次播放：开启时由首页自动播放逻辑
+  /// 接管，避免两套加载流程竞争覆盖同一播放源。
+  static Future<bool> isAutoPlayOnStartup() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_autoPlayOnStartupSettingKey) ?? false;
   }
 
   /// 开关开机自启播放歌曲功能。
@@ -1801,6 +1819,9 @@ class PlayerController extends ChangeNotifier {
     unawaited(_applyBassBoost());
     unawaited(_applyVolumeNormalization());
     notifyListeners();
+    if (!_settingsRestored.isCompleted) {
+      _settingsRestored.complete();
+    }
   }
 
   List<int> _restoreEqualizerLevels(String? raw) {

--- a/lib/controllers/player_controller.dart
+++ b/lib/controllers/player_controller.dart
@@ -50,6 +50,8 @@ class PlayerController extends ChangeNotifier {
   static const _desktopLyricsSettingsKey = 'settings.desktop_lyrics_settings';
   static const _smartQualitySettingKey = 'settings.smart_quality_enabled';
   static const _autoPlayOnStartupSettingKey = 'settings.auto_play_on_startup';
+  static const _resumeLastPlaylistOnStartupSettingKey =
+      'settings.resume_last_playlist_on_startup';
   static const _autoPlayOnDeviceConnectedSettingKey =
       'settings.auto_play_on_device_connected';
   static const _volumeNormalizationEnabledSettingKey =
@@ -243,6 +245,7 @@ class PlayerController extends ChangeNotifier {
   /// 是否开启音质智能切换（播放失败时自动降级重试）。
   bool smartQualityEnabled = false;
   bool autoPlayOnStartupEnabled = false;
+  bool resumeLastPlaylistOnStartupEnabled = false;
   double playbackSpeed = 1.0;
   bool equalizerEnabled = false;
   List<int> equalizerLevels = List<int>.of(_defaultEqualizerLevels);
@@ -671,12 +674,40 @@ class PlayerController extends ChangeNotifier {
     return prefs.getBool(_autoPlayOnStartupSettingKey) ?? false;
   }
 
-  /// 开关开机自启播放歌曲功能。
+  /// “恢复上次播放列表”开关当前是否已开启（从持久化存储读取）。
+  static Future<bool> isResumeLastPlaylistOnStartup() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_resumeLastPlaylistOnStartupSettingKey) ?? false;
+  }
+
+  /// 开关开机自启播放（推荐歌单）。
+  ///
+  /// 与“恢复上次播放列表”互斥：开启时自动关闭另一项，两项只能启用其一。
   Future<void> setAutoPlayOnStartupEnabled(bool enabled) async {
     if (autoPlayOnStartupEnabled == enabled) return;
     autoPlayOnStartupEnabled = enabled;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_autoPlayOnStartupSettingKey, enabled);
+    if (enabled && resumeLastPlaylistOnStartupEnabled) {
+      resumeLastPlaylistOnStartupEnabled = false;
+      await prefs.setBool(_resumeLastPlaylistOnStartupSettingKey, false);
+    }
+    notifyListeners();
+  }
+
+  /// 开关“打开应用时自动加载并播放上一次播放的列表”。
+  ///
+  /// 与“开机自启播放（推荐歌单）”互斥：开启时自动关闭另一项，保持只启用其一。
+  Future<void> setResumeLastPlaylistOnStartupEnabled(bool enabled) async {
+    if (resumeLastPlaylistOnStartupEnabled == enabled) return;
+    resumeLastPlaylistOnStartupEnabled = enabled;
+    if (enabled && autoPlayOnStartupEnabled) {
+      autoPlayOnStartupEnabled = false;
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_autoPlayOnStartupSettingKey, false);
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_resumeLastPlaylistOnStartupSettingKey, enabled);
     notifyListeners();
   }
 
@@ -1770,6 +1801,9 @@ class PlayerController extends ChangeNotifier {
         prefs.getBool(_smartQualitySettingKey) ?? smartQualityEnabled;
     autoPlayOnStartupEnabled =
         prefs.getBool(_autoPlayOnStartupSettingKey) ?? autoPlayOnStartupEnabled;
+    resumeLastPlaylistOnStartupEnabled =
+        prefs.getBool(_resumeLastPlaylistOnStartupSettingKey) ??
+        resumeLastPlaylistOnStartupEnabled;
     equalizerEnabled =
         prefs.getBool(_equalizerEnabledSettingKey) ?? equalizerEnabled;
     equalizerPresetName =
@@ -2304,8 +2338,10 @@ class PlayerController extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// 在恢复队列后加载并准备播放当前歌曲（不自动播放，仅预加载）。
-  Future<void> prepareRestoredSong() async {
+  /// 在恢复队列后加载并准备播放当前歌曲（默认不自动播放，仅预加载）。
+  ///
+  /// [autoPlay] 为 true 时（“恢复上次播放列表”开机模式）加载完成后立即播放。
+  Future<void> prepareRestoredSong({bool autoPlay = false}) async {
     final song = currentSong;
     if (song == null) return;
     climax = null;
@@ -2344,6 +2380,12 @@ class PlayerController extends ChangeNotifier {
 
       unawaited(loadLyrics(song));
       _startPositionSaving();
+      if (autoPlay) {
+        await _audioHandler.play();
+        // 记录播放历史与本地播放统计（后台执行，不阻塞播放）
+        unawaited(_historyService.record(song));
+        unawaited(_statsService.recordPlay(song));
+      }
     } catch (e) {
       debugPrint('[KA Music] Failed to prepare restored song: $e');
     } finally {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,9 +104,26 @@ class _KaMusicAppState extends State<KaMusicApp> with WidgetsBindingObserver {
   /// 恢复上次的播放队列和进度。
   Future<void> _restorePlaybackState() async {
     await _player.restoreQueueState();
-    // 开机自启播放开启时，不预加载上次的歌曲：首页的自动播放逻辑会
-    // 用每日推荐歌单接管，避免恢复队列与自动播放竞争覆盖同一播放源。
+    // 开机自启播放（推荐歌单）开启时，不预加载上次的歌曲：首页的自动播放逻辑
+    // 会用每日推荐歌单接管，避免恢复队列与自动播放竞争覆盖同一播放源。
     if (await PlayerController.isAutoPlayOnStartup()) {
+      return;
+    }
+    // “恢复上次播放列表”开启时：恢复上次队列/进度并自动播放（与推荐歌单互斥，
+    // 不会走到上述分支）。本地无记录则尝试服务端「继续播放」。
+    if (await PlayerController.isResumeLastPlaylistOnStartup()) {
+      if (_player.currentSong != null) {
+        unawaited(_player.prepareRestoredSong(autoPlay: true));
+        return;
+      }
+      try {
+        final latest = await _api.latestListenSongs();
+        if (_player.currentSong != null || latest.songs.isEmpty) return;
+        _player.restoreFromServerQueue(latest.songs);
+        unawaited(_player.prepareRestoredSong(autoPlay: true));
+      } catch (_) {
+        // 服务端恢复失败静默忽略，保持空状态。
+      }
       return;
     }
     if (_player.currentSong != null) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,6 +104,11 @@ class _KaMusicAppState extends State<KaMusicApp> with WidgetsBindingObserver {
   /// 恢复上次的播放队列和进度。
   Future<void> _restorePlaybackState() async {
     await _player.restoreQueueState();
+    // 开机自启播放开启时，不预加载上次的歌曲：首页的自动播放逻辑会
+    // 用每日推荐歌单接管，避免恢复队列与自动播放竞争覆盖同一播放源。
+    if (await PlayerController.isAutoPlayOnStartup()) {
+      return;
+    }
     if (_player.currentSong != null) {
       unawaited(_player.prepareRestoredSong());
       return;

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -80,7 +81,7 @@ class _HomePageState extends State<HomePage> {
     final cached = _cachedData;
     if (cached != null) {
       _future = Future.value(cached);
-      _checkAndAutoPlay(cached);
+      unawaited(_checkAndAutoPlay(cached));
       // 有缓存数据，立即显示并后台静默刷新
       _silentRefresh();
     } else if (!widget.auth.isRestoring) {
@@ -133,32 +134,58 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  void _checkAndAutoPlay(_HomeData data) {
-    if (widget.player.autoPlayOnStartupEnabled &&
-        !_hasAutoPlayed &&
-        widget.player.currentSong == null) {
+  /// 开机自启播放：打开应用后自动加载并播放每日推荐歌单。
+  ///
+  /// 原实现要求 [PlayerController.currentSong] 为 null 才触发，但应用启动时
+  /// main.dart 的 _restorePlaybackState() 总会先从本地/服务端恢复上次播放的
+  /// currentSong，导致该条件几乎永远不成立，开关形同虚设。
+  /// 改为“当前未在播放”时即触发；同时等待持久化设置恢复完成，
+  /// 避免开关尚未从磁盘读出时被误判为关闭。
+  Future<void> _checkAndAutoPlay(_HomeData data) async {
+    if (_hasAutoPlayed) return;
+    // 等待播放器设置恢复完成（含开机自启开关），最多兜底 2 秒，
+    // 防止 SharedPreferences 异常时永久挂起。
+    await Future.any([
+      widget.player.settingsRestored,
+      Future<void>.delayed(const Duration(seconds: 2)),
+    ]);
+    if (!mounted || _hasAutoPlayed) return;
+    // 已有歌曲正在播放（例如通知栏/后台恢复），不抢占。
+    if (widget.player.isPlaying) {
       _hasAutoPlayed = true;
-      final songs = data.daily.songs;
-      if (songs.isNotEmpty) {
-        // 必须推迟到首帧构建完成后执行：_checkAndAutoPlay 会在 initState
-        // 阶段被同步调用，此时直接调用 playSong 会触发 notifyListeners()，
-        // 违反 Flutter "build 阶段不能触发 setState/notifyListeners" 规则。
-        // 叠加 Windows 平台 just_audio 的 WinRT MediaPlayer COM 线程在应用
-        // 启动早期尚未完全就绪，立即 setUrl()/play() 会与 UI 渲染竞争，
-        // 导致 "Lost connection to device" 进程崩溃。
-        // Windows 上额外延迟 300ms 让 native 层完全稳定后再启动播放。
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-          final delay = Platform.isWindows
-              ? const Duration(milliseconds: 300)
-              : Duration.zero;
-          Future<void>.delayed(delay, () {
-            if (!mounted) return;
-            widget.player.playSong(songs.first, queue: songs);
-          });
-        });
-      }
+      return;
     }
+    if (!widget.player.autoPlayOnStartupEnabled) return;
+    final songs = data.daily.songs;
+    if (songs.isEmpty) {
+      // 推荐歌单不可用（无网/无缓存）时的降级：预加载上次播放的歌曲。
+      // 自启开启时 main.dart 跳过了预加载，这里补上，保证用户仍能手动播放。
+      if (widget.player.currentSong != null) {
+        unawaited(widget.player.prepareRestoredSong());
+      }
+      return;
+    }
+    _hasAutoPlayed = true;
+    // 必须推迟到首帧构建完成后执行：_checkAndAutoPlay 会在 initState
+    // 阶段被同步调用，此时直接调用 playSong 会触发 notifyListeners()，
+    // 违反 Flutter "build 阶段不能触发 setState/notifyListeners" 规则。
+    // 叠加 Windows 平台 just_audio 的 WinRT MediaPlayer COM 线程在应用
+    // 启动早期尚未完全就绪，立即 setUrl()/play() 会与 UI 渲染竞争，
+    // 导致 "Lost connection to device" 进程崩溃。
+    // Windows 上额外延迟 300ms 让 native 层完全稳定后再启动播放。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final delay = Platform.isWindows
+          ? const Duration(milliseconds: 300)
+          : Duration.zero;
+      Future<void>.delayed(delay, () {
+        if (!mounted) return;
+        // 二次校验：等待期间用户可能已手动开始播放或关闭开关。
+        if (!widget.player.autoPlayOnStartupEnabled) return;
+        if (widget.player.isPlaying) return;
+        widget.player.playSong(songs.first, queue: songs);
+      });
+    });
   }
 
   /// 后台静默刷新首页数据。
@@ -185,6 +212,8 @@ class _HomePageState extends State<HomePage> {
         recommendedSongCards: results[5] as List<RecommendedSongCard>,
       );
       _cachedData = data;
+      // 先触发自启播放，避免缓存写入失败（磁盘异常等）连带影响自动播放。
+      unawaited(_checkAndAutoPlay(data));
       await widget.cache.write('cache_home', {
         'daily': data.daily.toCache(),
         'playlists': data.playlists.map((p) => p.toCache()).toList(),
@@ -196,7 +225,6 @@ class _HomePageState extends State<HomePage> {
             .toList(),
       });
       if (!mounted) return;
-      _checkAndAutoPlay(data);
       setState(() {
         _future = Future.value(data);
       });
@@ -223,6 +251,8 @@ class _HomePageState extends State<HomePage> {
       recommendedSongCards: results[5] as List<RecommendedSongCard>,
     );
     _cachedData = data;
+    // 先触发自启播放，避免缓存写入失败（磁盘异常等）连带影响自动播放。
+    unawaited(_checkAndAutoPlay(data));
     await widget.cache.write('cache_home', {
       'daily': data.daily.toCache(),
       'playlists': data.playlists.map((p) => p.toCache()).toList(),
@@ -233,7 +263,6 @@ class _HomePageState extends State<HomePage> {
           .map((card) => card.toCache())
           .toList(),
     });
-    _checkAndAutoPlay(data);
     return data;
   }
 
@@ -247,7 +276,7 @@ class _HomePageState extends State<HomePage> {
     if (cached != null) {
       final data = _homeDataFromCache(cached.data);
       _cachedData = data;
-      _checkAndAutoPlay(data);
+      unawaited(_checkAndAutoPlay(data));
       setState(() {
         _future = Future.value(data);
       });

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -205,6 +205,15 @@ class SettingsPage extends StatelessWidget {
                     ),
                     _SettingsDivider(),
                     _SettingsSwitchTile(
+                      icon: Icons.history_rounded,
+                      iconColor: colorScheme.primary,
+                      title: '恢复上次播放列表',
+                      subtitle: '打开应用时自动加载并播放上一次播放的列表（与开机自启播放互斥）',
+                      value: player.resumeLastPlaylistOnStartupEnabled,
+                      onChanged: player.setResumeLastPlaylistOnStartupEnabled,
+                    ),
+                    _SettingsDivider(),
+                    _SettingsSwitchTile(
                       icon: Icons.bluetooth_audio_rounded,
                       iconColor: colorScheme.primary,
                       title: '连接新音频设备自动播放',


### PR DESCRIPTION
## 功能说明

搜索页新增「单曲/专辑」类型切换，支持搜索专辑：

- music_api: 新增 getAllAlbums? 不——是 searchAlbums()，与 searchSongs 共用 /search 接口（type=album）
- search_page: 新增类型切换栏（单曲/专辑），专辑结果列表展示封面/专辑名/歌手/发行日期，点击复用 PlaylistDetailPage 展示专辑曲目
- 专辑模式隐藏平台切换（专辑搜索仅酷狗源），搜索框提示语补充专辑

## 修复
- ArtistAlbum.fromJson 兼容 Kugou 搜索接口小写字段（albumid/albumname/singer/img/publish_time），修复专辑搜索结果恒为空的 bug

## 已通过验证
- Android APK CI 构建 success（run 34955020617）
- iOS IPA CI 构建 success（run 34955020497）